### PR TITLE
Update README heading and add build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-"# CoShift" 
+# CoShift
 Ich bin Teil eines genossenschaftlichen Supermarktes mit etwa 500 Mitgliedern. In diesem Supermarkt darf  man nur als Mitglied einkaufen. Im Monat muss man 1 Schicht à 3 Stunden leisten. Die ersparten Ausgaben für Personal machen die Waren billiger. 
 
 Ich möchte eine Anwendung entwickeln, mit der man Schichten verwalten und sich zum Arbeiten anmelden kann. Die App soll zuerst nur als Website erreichbar sein. Später soll es möglicherweise eine App fürs Handy geben. 
@@ -10,3 +10,20 @@ Ich möchte in dem Projekt TestDrivenDevolopment üben. Vorher habe ich ein Buch
 Als erstes "walking skeleton" möchte ich folgendes etablieren: Ich logge mich ein. Ich sehe erst einmal nur eine Schicht und mein Stundenkonto in einem Zeitplan. 
 
 Die Technologien, die ich benutzen möchte sind Java, Spring, React, Maven, Git.
+
+## Building the project
+
+To build the Spring Boot backend run the Maven wrapper:
+
+```bash
+cd CoShift
+./mvnw clean package
+```
+
+To build the React frontend run:
+
+```bash
+cd CoShift/frontend
+npm install
+npm run build
+```


### PR DESCRIPTION
## Summary
- fix README header formatting
- document how to build the backend and frontend

## Testing
- `./mvnw test` *(fails: Could not resolve Spring Boot parent)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685812d9260c832d932806db989cb949