### PR TITLE
Implement ShiftController and basic auth test

### DIFF
--- a/CoShift/src/main/java/org/coshift/b_application/UseCaseInteractor.java
+++ b/CoShift/src/main/java/org/coshift/b_application/UseCaseInteractor.java
@@ -2,7 +2,7 @@ package org.coshift.b_application;
 
 import org.coshift.a_domain.Person;
 import org.coshift.a_domain.Shift;
-
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,6 +15,8 @@ import java.util.List;
  *  – Keine eigene Business-Logik<br>
  *  – Delegiert an die spezialisierten Use-Cases
  */
+
+@Component
 public class UseCaseInteractor {
 
     private final AddShiftUseCase  addShiftUC;

--- a/CoShift/src/main/java/org/coshift/d_frameworks/web/ShiftController.java
+++ b/CoShift/src/main/java/org/coshift/d_frameworks/web/ShiftController.java
@@ -1,26 +1,31 @@
-// package org.coshift.d_frameworks.web;
+package org.coshift.d_frameworks.web;
 
-// import org.coshift.d_frameworks.db.ShiftJpaEntity;
-// import org.springframework.web.bind.annotation.GetMapping;
-// import org.springframework.web.bind.annotation.RequestMapping;
-// import org.springframework.web.bind.annotation.RestController;
+import org.coshift.b_application.UseCaseInteractor;
+import org.coshift.c_adapters.ShiftDto;
+import org.coshift.c_adapters.ShiftMapper;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-// import java.time.LocalDate;
-// import java.time.LocalTime;
-// import java.util.List;
+import java.util.List;
 
-// @RestController
-// @RequestMapping("/api/shifts")
-// class ShiftController {
+/**
+ * REST controller exposing shift information.
+ */
+@RestController
+@RequestMapping("/api/shifts")
+class ShiftController {
 
-//     @GetMapping
-//     public List<ShiftJpaEntity> all() {
-//         // Walking-Skeleton: genau **eine** Demo-Schicht zurückgeben
-//         return List.of(
-//                 new ShiftJpaEntity(
-//                         LocalDate.now(),
-//                         LocalTime.of(18, 0),
-//                         LocalTime.of(21, 0))
-//         );
-//     }
-// }
+    private final UseCaseInteractor interactor;
+
+    ShiftController(UseCaseInteractor interactor) {
+        this.interactor = interactor;
+    }
+
+    @GetMapping
+    public List<ShiftDto> all() {
+        return interactor.getAllShifts().stream()
+                .map(ShiftMapper::toDto)
+                .toList();
+    }
+}

--- a/CoShift/src/test/java/org/coshift/d_frameworks/web/ShiftControllerTest.java
+++ b/CoShift/src/test/java/org/coshift/d_frameworks/web/ShiftControllerTest.java
@@ -1,29 +1,41 @@
-// package org.coshift.d_frameworks.web;              // an deine Paketstruktur anpassen
+package org.coshift.d_frameworks.web;
 
-// import org.coshift.d_frameworks.config.SecurityConfig;
-// import org.junit.jupiter.api.Test;
-// import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-// import org.springframework.context.annotation.Import;
-// import org.springframework.test.web.servlet.MockMvc;
+import org.coshift.a_domain.Shift;
+import org.coshift.b_application.UseCaseInteractor;
+import org.coshift.d_frameworks.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
 
-// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-// import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
-// import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-// import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import java.time.LocalDateTime;
+import java.util.List;
 
-// @WebMvcTest(ShiftController.class)
-// @Import(SecurityConfig.class)   // falls SecurityConfig in anderem Package liegt
-// class ShiftControllerTest {
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-//     @Autowired
-//     MockMvc mvc;
+@WebMvcTest(ShiftController.class)
+@Import(SecurityConfig.class)
+class ShiftControllerTest {
 
-//     @Test
-//     void shouldReturnOneDemoShift() throws Exception {
-//         mvc.perform(get("/api/shifts")
-//                         .with(httpBasic("mitglied", "secret")))
-//                 .andExpect(status().isOk())
-//                 .andExpect(jsonPath("$.length()").value(1));
-//     }
-// }
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    UseCaseInteractor interactor;
+
+    @Test
+    void authenticatedRequestReturnsShifts() throws Exception {
+        List<Shift> shifts = List.of(new Shift(1L, LocalDateTime.now(), 120, 10));
+        when(interactor.getAllShifts()).thenReturn(shifts);
+
+        mvc.perform(get("/api/shifts").with(httpBasic("mitglied", "secret")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+    }
+}


### PR DESCRIPTION
## Summary
- revive `ShiftController` and expose `/api/shifts`
- create `UseCaseInteractor` bean
- add security test for authenticated shift retrieval

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685812adc748832dbae1609e0f1431b1