### PR TITLE
Add ShiftWeekView component

### DIFF
--- a/CoShift/frontend/src/App.css
+++ b/CoShift/frontend/src/App.css
@@ -40,3 +40,23 @@
 .read-the-docs {
   color: #888;
 }
+
+.week-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.day-column {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  min-height: 6rem;
+}
+
+.shift-card {
+  background: #f8f8f8;
+  margin: 0.25rem 0;
+  padding: 0.25rem;
+  border-radius: 4px;
+}

--- a/CoShift/frontend/src/App.tsx
+++ b/CoShift/frontend/src/App.tsx
@@ -1,34 +1,9 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import ShiftWeekView from './ShiftWeekView'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <ShiftWeekView />
   )
 }
 

--- a/CoShift/frontend/src/ShiftWeekView.tsx
+++ b/CoShift/frontend/src/ShiftWeekView.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import './App.css'
+
+interface Shift {
+  id: number
+  startTime: string
+}
+
+export default function ShiftWeekView() {
+  const [shifts, setShifts] = useState<Shift[]>([])
+
+  useEffect(() => {
+    fetch('/api/shifts')
+      .then(res => res.json())
+      .then(data => setShifts(data))
+      .catch(err => console.error('Failed to fetch shifts', err))
+  }, [])
+
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+  const shiftsByDay = days.map((_, i) =>
+    shifts.filter(s => {
+      const date = new Date(s.startTime)
+      const jsDay = date.getDay() // 0 Sun, 1 Mon, ...
+      const dayIndex = (jsDay + 6) % 7 // convert so Monday=0
+      return dayIndex === i
+    })
+  )
+
+  return (
+    <div className="week-grid">
+      {days.map((day, idx) => (
+        <div key={day} className="day-column">
+          <h3>{day}</h3>
+          {shiftsByDay[idx].map(shift => (
+            <div key={shift.id} className="shift-card">
+              <div>ID: {shift.id}</div>
+              <div>{new Date(shift.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</div>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `ShiftWeekView.tsx` for displaying shifts grouped by day
- replace default `App.tsx` layout with `<ShiftWeekView/>`
- add simple styling for grid, columns and shift cards

## Testing
- `npm run lint`
- `npm run build`
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685812c1c364832da81e200ecb2a53d4