### PR TITLE
Re-enable security and add simple login UI

### DIFF
--- a/CoShift/frontend/src/App.css
+++ b/CoShift/frontend/src/App.css
@@ -67,3 +67,6 @@
   padding: 0.25rem;
   border-radius: 4px;
 }
+
+.login-form input { margin: 0.25rem; }
+

--- a/CoShift/frontend/src/App.tsx
+++ b/CoShift/frontend/src/App.tsx
@@ -1,8 +1,12 @@
 import './App.css'
 import WeekView from './WeekView'
+import Login from './Login'
+import { useState } from 'react'
 
 export default function App() {
-  return (
-    <WeekView />
-  )
+  const [auth, setAuth] = useState<string | null>(null)
+
+  return auth
+    ? <WeekView authHeader={auth} />
+    : <Login onLogin={setAuth} />
 }

--- a/CoShift/frontend/src/Login.tsx
+++ b/CoShift/frontend/src/Login.tsx
@@ -1,0 +1,25 @@
+import { useState, FormEvent } from 'react'
+
+interface Props {
+  onLogin: (authHeader: string) => void
+}
+
+export default function Login({ onLogin }: Props) {
+  const [user, setUser] = useState('')
+  const [pass, setPass] = useState('')
+
+  function submit(e: FormEvent) {
+    e.preventDefault()
+    const token = btoa(`${user}:${pass}`)
+    onLogin(`Basic ${token}`)
+  }
+
+  return (
+    <form onSubmit={submit} className="login-form">
+      <input value={user} onChange={e => setUser(e.target.value)} placeholder="User" />
+      <input type="password" value={pass} onChange={e => setPass(e.target.value)} placeholder="Password" />
+      <button type="submit">Login</button>
+    </form>
+  )
+}
+

--- a/CoShift/frontend/src/WeekView.tsx
+++ b/CoShift/frontend/src/WeekView.tsx
@@ -8,18 +8,24 @@ export interface DayCellViewModel {
   fullyStaffed: boolean
 }
 
-export default function WeekView() {
+interface Props {
+  authHeader?: string
+}
+
+export default function WeekView({ authHeader }: Props) {
   const [cells, setCells] = useState<DayCellViewModel[]>([])
 
   useEffect(() => {
-    fetch('/api/week')
+    fetch('/api/week', {
+      headers: authHeader ? { Authorization: authHeader } : {}
+    })
       .then(res => {
         if (!res.ok) throw new Error('Network response was not ok')
         return res.json()
       })
       .then((data: DayCellViewModel[]) => setCells(data))
       .catch(err => console.error('Failed to load week data', err))
-  }, [])
+  }, [authHeader])
 
   // Kopfzeile
   const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']

--- a/CoShift/src/main/java/org/coshift/d_frameworks/config/SecurityConfig.java
+++ b/CoShift/src/main/java/org/coshift/d_frameworks/config/SecurityConfig.java
@@ -15,28 +15,15 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    // @Bean
-    // SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    //     http
-    //             .csrf(c -> c.disable())
-    //             .authorizeHttpRequests(a -> a
-    //                     .requestMatchers("/api/**").authenticated()
-    //                     .anyRequest().permitAll())
-    //             .httpBasic(Customizer.withDefaults())   //  ← NEU
-    //             .formLogin(Customizer.withDefaults());  //  ← darf bleiben
-    //     return http.build();
-    // }
-
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            // CSRF und CORS im Dev-Modus abschalten
-            .csrf(csrf -> csrf.disable())
-            .cors(cors -> cors.disable())
-    
-            // ALLE Requests erlauben
-            .authorizeHttpRequests(a -> a.anyRequest().permitAll());
-    
+            .csrf(c -> c.disable())
+            .authorizeHttpRequests(a -> a
+                    .requestMatchers("/api/**").authenticated()
+                    .anyRequest().permitAll())
+            .httpBasic(Customizer.withDefaults())
+            .formLogin(Customizer.withDefaults());
         return http.build();
     }
 

--- a/CoShift/src/test/java/org/coshift/d_frameworks/web/ShiftControllerTest.java
+++ b/CoShift/src/test/java/org/coshift/d_frameworks/web/ShiftControllerTest.java
@@ -38,4 +38,10 @@ class ShiftControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1));
     }
+
+    @Test
+    void unauthenticatedRequestIsRejected() throws Exception {
+        mvc.perform(get("/api/shifts"))
+                .andExpect(status().isUnauthorized());
+    }
 }


### PR DESCRIPTION
## Summary
- require authentication for `/api/**` again
- add unauthenticated request test
- implement a small login form and pass credentials to the week view

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*
- `npm run build` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68654dd7edf4832d94fe3ad57a23e075