### PR TITLE
feat: introduce reusable auth hook

### DIFF
--- a/CoShift/frontend/src/app/App.tsx
+++ b/CoShift/frontend/src/app/App.tsx
@@ -1,87 +1,31 @@
-import { useState, useCallback, useEffect } from 'react'
 import './App.css'
-import Login       from '../feature/auth/LoginForm'
-import WeekView    from '../feature/week/WeekView'
-import Layout      from '../layout/Layout'
+import Login from '../feature/auth/LoginForm'
+import WeekView from '../feature/week/WeekView'
+import Layout from '../layout/Layout'
 import PrivateLayout from '../layout/PrivateLayout'
 import { AuthContext } from '../feature/auth/AuthContext'
 import { Routes, Route, Navigate } from 'react-router-dom'
-import AdminPage   from '../feature/admin/AdminPage'   // gleich anlegen, siehe unten
+import AdminPage from '../feature/admin/AdminPage'
+import useAuth from '../feature/auth/useAuth'
 
 /**
  * Root-Komponente:
- * – Verwaltet den Auth-Header im State.
- * – Reicht eine „tryLogin“-Funktion an <Login/> durch, die
- *   einen Probe-Call auf ein geschütztes Backend-API macht.
- * – Zeigt nach erfolgreichem Login die <WeekView/>.
+ * – Verwaltet den Auth-Status über einen Hook.
+ * – Stellt Routen und den AuthContext bereit.
  */
 export default function App() {
-  const [authHeader, setAuthHeader] = useState<string | null>(null)
-  const [balance,    setBalance]    = useState<number | null>(null)
-
-
-
-  const tryLogin = useCallback(async (header: string): Promise<boolean> => {
-    try {
-      const res = await fetch('/api/shifts', {
-        headers: { Authorization: header }
-      })
-
-      if (res.ok) {
-        setAuthHeader(header)
-        sessionStorage.setItem('authHeader', header)
-
-        // Saldo laden
-        try {
-          const balRes = await fetch('/api/persons/me/timeaccount', {
-            headers: { Authorization: header }
-          })
-          if (balRes.ok) {
-            const dto = await balRes.json() as { balanceInMinutes: number }
-            setBalance(dto.balanceInMinutes)
-          }
-        } catch (e) {
-          console.error('Unable to fetch balance', e)
-        }
-
-        return true
-      }
-    } catch {
-      console.error('Api unavailable')
-    }
-    sessionStorage.removeItem('authHeader')
-    return false                         // 401 
-  }, [])
-
-  function logout() {
-    setAuthHeader(null)
-    setBalance(null)
-    sessionStorage.removeItem('authHeader')        
-  }
-
-  useEffect(() => {
-    const stored = sessionStorage.getItem('authHeader')
-    if (stored) {
-      // Schnelltest: ist das Token noch gültig?
-      tryLogin(stored).catch(() => {
-        sessionStorage.removeItem('authHeader')
-      })
-    }
-  }, [tryLogin])
-  
-
-
+  const auth = useAuth()
 
   return (
-    <AuthContext.Provider value={{ header: authHeader, balance, logout }}>
-      {authHeader && <Layout />}          {/* <- MUI-AppBar inkl. Burger */}
+    <AuthContext.Provider value={auth}>
+      {auth.header && <Layout />}
 
-      {!authHeader ? (
-        <Login onLogin={tryLogin} />
+      {!auth.header ? (
+        <Login onLogin={auth.login} />
       ) : (
         <Routes>
           <Route element={<PrivateLayout />}>
-            <Route path="/"      element={<WeekView />} />
+            <Route path="/" element={<WeekView />} />
             <Route path="/admin" element={<AdminPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" />} />
@@ -90,3 +34,4 @@ export default function App() {
     </AuthContext.Provider>
   )
 }
+

--- a/CoShift/frontend/src/feature/auth/AuthContext.tsx
+++ b/CoShift/frontend/src/feature/auth/AuthContext.tsx
@@ -1,13 +1,11 @@
 import { createContext, useContext } from 'react'
+import type useAuth from './useAuth'
 
-export interface AuthCtx {
-  header:  string | null
-  balance: number | null
-  logout: () => void
-}
+export type AuthCtx = ReturnType<typeof useAuth>
 export const AuthContext = createContext<AuthCtx | null>(null)
 export const useAuth = () => {
   const ctx = useContext(AuthContext)
   if (!ctx) throw new Error('useAuth must be inside <AuthContext.Provider>')
   return ctx
 }
+

--- a/CoShift/frontend/src/feature/auth/useAuth.ts
+++ b/CoShift/frontend/src/feature/auth/useAuth.ts
@@ -1,0 +1,68 @@
+import { useState, useCallback, useEffect } from 'react'
+
+interface TimeAccountDto {
+  balanceInMinutes: number
+}
+
+export default function useAuth() {
+  const [header, setHeader] = useState<string | null>(null)
+  const [balance, setBalance] = useState<number | null>(null)
+
+  const loadBalance = useCallback(
+    async (overrideHeader?: string): Promise<void> => {
+      const auth = overrideHeader ?? header
+      if (!auth) return
+      try {
+        const res = await fetch('/api/persons/me/timeaccount', {
+          headers: { Authorization: auth }
+        })
+        if (res.ok) {
+          const dto = (await res.json()) as TimeAccountDto
+          setBalance(dto.balanceInMinutes)
+        }
+      } catch (e) {
+        console.error('Unable to fetch balance', e)
+      }
+    },
+    [header]
+  )
+
+  const login = useCallback(
+    async (auth: string): Promise<boolean> => {
+      try {
+        const res = await fetch('/api/shifts', {
+          headers: { Authorization: auth }
+        })
+        if (res.ok) {
+          setHeader(auth)
+          sessionStorage.setItem('authHeader', auth)
+          await loadBalance(auth)
+          return true
+        }
+      } catch {
+        console.error('Api unavailable')
+      }
+      sessionStorage.removeItem('authHeader')
+      return false
+    },
+    [loadBalance]
+  )
+
+  const logout = useCallback(() => {
+    setHeader(null)
+    setBalance(null)
+    sessionStorage.removeItem('authHeader')
+  }, [])
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('authHeader')
+    if (stored) {
+      login(stored).catch(() => {
+        sessionStorage.removeItem('authHeader')
+      })
+    }
+  }, [login])
+
+  return { header, balance, login, logout, loadBalance }
+}
+


### PR DESCRIPTION
## Summary
- move auth logic into reusable `useAuth` hook
- simplify `App` to provide routes and context via the hook
- align `AuthContext` with hook return values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc78ee454832dbbe63399fe5df095