### PR TITLE
Add useWeek hook and integrate with WeekView

### DIFF
--- a/CoShift/frontend/src/feature/week/DayCell.tsx
+++ b/CoShift/frontend/src/feature/week/DayCell.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material'
-import type { DayCellViewModel } from './WeekView'
+import type { DayCellViewModel } from './hooks/useWeek'
 
 export default function DayCell({ cell }: { cell: DayCellViewModel }) {
 

--- a/CoShift/frontend/src/feature/week/WeekView.tsx
+++ b/CoShift/frontend/src/feature/week/WeekView.tsx
@@ -1,41 +1,25 @@
-import { useEffect, useState } from 'react'
-import DayCell from './DayCell.tsx'     
-import { useAuth } from '../auth/AuthContext'
+import DayCell from './DayCell.tsx'
 import { Box } from '@mui/material'
-
-export interface ShiftCellVM {
-  startTime: string
-  fullyStaffed: boolean
-}
-
-export interface DayCellViewModel {
-  shifts: ShiftCellVM[]
-}
+import { useWeek, DayCellViewModel } from './hooks/useWeek'
 
 export default function WeekView() {
-  const { header: authHeader } = useAuth()
-  const weeksToShow = 3;
-  const EXPECTED = weeksToShow * 7;
+  const weeksToShow = 3
+  const EXPECTED = weeksToShow * 7
 
-  const [cells, setCells] = useState<DayCellViewModel[]>([])
+  const { data: cells = [], isLoading, isError } = useWeek(weeksToShow)
 
-  useEffect(() => {
-    fetch(`/api/week?count=${weeksToShow}`, {
-      headers: authHeader ? { Authorization: authHeader } : {}
-    })
-      .then(res => {
-        if (!res.ok) throw new Error('Network response was not ok')
-        return res.json()
-      })
-      .then((data: DayCellViewModel[]) => setCells(data))
-      .catch(err => console.error('Failed to load week data', err))
-  }, [authHeader])
+  if (isLoading) {
+    return <Box>Loading...</Box>
+  }
+
+  if (isError) {
+    return <Box>Error loading week data</Box>
+  }
 
   // Kopfzeile
   const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']
 
   // Fallback: solange noch keine Daten da sind, leere Zellen anzeigen
-  // test
   const empty: DayCellViewModel = { shifts: [] }
   const display = cells.length === EXPECTED
     ? cells

--- a/CoShift/frontend/src/feature/week/hooks/useWeek.ts
+++ b/CoShift/frontend/src/feature/week/hooks/useWeek.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+import { useAuth } from '../../auth/AuthContext'
+
+export interface ShiftCellVM {
+  startTime: string
+  fullyStaffed: boolean
+}
+
+export interface DayCellViewModel {
+  shifts: ShiftCellVM[]
+}
+
+async function fetchWeek(weeksToShow: number, header?: string): Promise<DayCellViewModel[]> {
+  const res = await fetch(`/api/week?count=${weeksToShow}`, {
+    headers: header ? { Authorization: header } : {},
+  })
+  if (!res.ok) throw new Error('Network response was not ok')
+  return res.json()
+}
+
+export function useWeek(weeksToShow: number) {
+  const { header } = useAuth()
+  return useQuery({
+    queryKey: ['week', weeksToShow],
+    queryFn: () => fetchWeek(weeksToShow, header),
+  })
+}


### PR DESCRIPTION
## Summary
- add useWeek hook for fetching week data via React Query
- refactor WeekView to use new hook and handle loading/error states
- align DayCell with shared DayCellViewModel type

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688dc795aed0832da038e6ed165a2fc3