### PR TITLE
refactor: improve login form with MUI

### DIFF
--- a/CoShift/frontend/src/feature/auth/LoginForm.tsx
+++ b/CoShift/frontend/src/feature/auth/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from 'react'
+import { TextField, Button, CircularProgress, Box } from '@mui/material'
 
 interface Props {
   /* Liefert true bei erfolgreichem Login, sonst false */
@@ -6,15 +7,18 @@ interface Props {
 }
 
 export default function Login({ onLogin }: Props) {
-  const [user,  setUser]  = useState('')
-  const [pass,  setPass]  = useState('')
+  const [user, setUser] = useState('')
+  const [pass, setPass] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
 
   async function submit(e: FormEvent) {
     e.preventDefault()
-    setError(null)                               // alte Fehlermeldung zurücksetzen
-    const token   = btoa(`${user}:${pass}`)
+    setError(null) // alte Fehlermeldung zurücksetzen
+    setLoading(true)
+    const token = btoa(`${user}:${pass}`)
     const success = await onLogin(`Basic ${token}`)
+    setLoading(false)
 
     if (!success) {
       setError('Benutzername oder Passwort falsch')
@@ -22,23 +26,34 @@ export default function Login({ onLogin }: Props) {
   }
 
   return (
-    <form onSubmit={submit} className="login-form">
-      <input
+    <Box
+      component="form"
+      onSubmit={submit}
+      className="login-form"
+      sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+    >
+      <TextField
         value={user}
         onChange={e => setUser(e.target.value)}
-        placeholder="User"
+        label="User"
         autoComplete="username"
       />
-      <input
+      <TextField
         type="password"
         value={pass}
         onChange={e => setPass(e.target.value)}
-        placeholder="Password"
+        label="Password"
         autoComplete="current-password"
       />
-      <button type="submit">Login</button>
+      <Button type="submit" variant="contained" disabled={loading}>
+        {loading ? <CircularProgress size={24} /> : 'Login'}
+      </Button>
 
-      {error && <div className="error-msg">{error}</div>}
-    </form>
+      {error && (
+        <Box className="error-msg" sx={{ color: 'error.main' }}>
+          {error}
+        </Box>
+      )}
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary
- replace raw inputs/buttons with MUI TextField and Button
- show CircularProgress while submitting
- wrap form in Box for MUI-friendly spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc79ad644832d9a841e8abd5109c1