### PR TITLE
refactor: extract header and nav drawer

### DIFF
--- a/CoShift/frontend/src/layout/Header.tsx
+++ b/CoShift/frontend/src/layout/Header.tsx
@@ -1,0 +1,25 @@
+import { AppBar, Toolbar, IconButton, Typography, Button } from '@mui/material'
+import MenuIcon      from '@mui/icons-material/Menu'
+import LogoutIcon    from '@mui/icons-material/Logout'
+import { useAuth }   from '../feature/auth/AuthContext'
+
+type HeaderProps = {
+  onMenuClick: () => void
+}
+
+export default function Header({ onMenuClick }: HeaderProps){
+  const { logout, balance } = useAuth()
+
+  return (
+    <AppBar position="fixed">
+      <Toolbar>
+        <IconButton color="inherit" edge="start" onClick={onMenuClick}>
+          <MenuIcon/>
+        </IconButton>
+        <Typography sx={{flexGrow:1}} variant="h6">CoShift</Typography>
+        {balance!==null && <Typography sx={{mr:2}}>{balance} min</Typography>}
+        <Button color="inherit" startIcon={<LogoutIcon/>} onClick={logout}>Logout</Button>
+      </Toolbar>
+    </AppBar>
+  )
+}

--- a/CoShift/frontend/src/layout/Layout.tsx
+++ b/CoShift/frontend/src/layout/Layout.tsx
@@ -1,49 +1,17 @@
 import { useState } from 'react'
-import { AppBar, Toolbar, IconButton, Typography, Drawer, List, ListItemButton, ListItemIcon, ListItemText, Box, Button } from '@mui/material'
-import MenuIcon      from '@mui/icons-material/Menu'
-import HomeIcon      from '@mui/icons-material/Home'
-import AdminPanelIcon from '@mui/icons-material/AdminPanelSettings'
-import LogoutIcon    from '@mui/icons-material/Logout'
-import { Link as RouterLink, useLocation } from 'react-router-dom'
-import { useAuth }   from '../feature/auth/AuthContext'
+import { Toolbar } from '@mui/material'
+import Header    from './Header'
+import NavDrawer from './NavDrawer'
 
 export default function Layout(){
   const [open,setOpen]=useState(false)
-  const { logout, balance } = useAuth()
-  const loc = useLocation()
 
   return (
     <>
-      {/* Header */}
-      <AppBar position="fixed">
-        <Toolbar>
-          <IconButton color="inherit" edge="start" onClick={()=>setOpen(true)}>
-            <MenuIcon/>
-          </IconButton>
-          <Typography sx={{flexGrow:1}} variant="h6">CoShift</Typography>
-          {balance!==null && <Typography sx={{mr:2}}>{balance} min</Typography>}
-          <Button color="inherit" startIcon={<LogoutIcon/>} onClick={logout}>Logout</Button>
-        </Toolbar>
-      </AppBar>
-
-      {/* Drawer */}
-      <Drawer open={open} onClose={()=>setOpen(false)}>
-        <Box sx={{width:240}} role="presentation" onClick={()=>setOpen(false)}>
-          <List>
-            <ListItemButton component={RouterLink} to="/" selected={loc.pathname==='/'}>
-              <ListItemIcon><HomeIcon/></ListItemIcon>
-              <ListItemText primary="Übersicht"/>
-            </ListItemButton>
-            <ListItemButton component={RouterLink} to="/admin" selected={loc.pathname==='/admin'}>
-              <ListItemIcon><AdminPanelIcon/></ListItemIcon>
-              <ListItemText primary="Admin"/>
-            </ListItemButton>
-          </List>
-        </Box>
-      </Drawer>
-
+      <Header onMenuClick={()=>setOpen(true)}/>
+      <NavDrawer open={open} onClose={()=>setOpen(false)}/>
       {/* Platz für Inhalt unter der AppBar */}
-      <Toolbar/>  {/* push content under fixed AppBar */}
+      <Toolbar/>
     </>
   )
-} 
+}

--- a/CoShift/frontend/src/layout/NavDrawer.tsx
+++ b/CoShift/frontend/src/layout/NavDrawer.tsx
@@ -1,0 +1,31 @@
+import { Drawer, List, ListItemButton, ListItemIcon, ListItemText, Box } from '@mui/material'
+import HomeIcon      from '@mui/icons-material/Home'
+import AdminPanelIcon from '@mui/icons-material/AdminPanelSettings'
+import { Link as RouterLink, useLocation } from 'react-router-dom'
+
+type NavDrawerProps = {
+  open: boolean
+  onClose: () => void
+}
+
+export default function NavDrawer({ open, onClose }: NavDrawerProps){
+  const loc = useLocation()
+  const handleClose = () => onClose()
+
+  return (
+    <Drawer open={open} onClose={handleClose}>
+      <Box sx={{width:240}} role="presentation" onClick={handleClose}>
+        <List>
+          <ListItemButton component={RouterLink} to="/" selected={loc.pathname==='/'}>
+            <ListItemIcon><HomeIcon/></ListItemIcon>
+            <ListItemText primary="Übersicht"/>
+          </ListItemButton>
+          <ListItemButton component={RouterLink} to="/admin" selected={loc.pathname==='/admin'}>
+            <ListItemIcon><AdminPanelIcon/></ListItemIcon>
+            <ListItemText primary="Admin"/>
+          </ListItemButton>
+        </List>
+      </Box>
+    </Drawer>
+  )
+}


### PR DESCRIPTION
## Summary
- move AppBar and logout logic into Header component
- move navigation drawer and menu items into NavDrawer component
- simplify Layout to compose Header, NavDrawer, and content placeholder

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc7a04fd4832daac63e11d5225027