### PR TITLE
feat: central api client with auth header

### DIFF
--- a/CoShift/frontend/src/api/client.ts
+++ b/CoShift/frontend/src/api/client.ts
@@ -1,0 +1,74 @@
+import { useAuth } from '../feature/auth/AuthContext'
+
+// Generic request helper with central error handling
+async function request<T>(
+  method: string,
+  url: string,
+  {
+    body,
+    headers: customHeaders,
+    ...options
+  }: RequestInit & { body?: unknown } = {}
+): Promise<T> {
+  const headers: HeadersInit = {
+    ...(body ? { 'Content-Type': 'application/json' } : {}),
+    ...(customHeaders || {}),
+  }
+
+  try {
+    const res = await fetch(url, {
+      ...options,
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    })
+
+    if (!res.ok) {
+      const msg = `Request failed with status ${res.status}`
+      console.error(msg)
+      if (typeof window !== 'undefined') window.alert(msg)
+      throw new Error(msg)
+    }
+
+    if (res.status === 204) return null as T
+    return res.json() as Promise<T>
+  } catch (err) {
+    console.error('Network error', err)
+    if (typeof window !== 'undefined') window.alert('Network error')
+    throw err
+  }
+}
+
+// Base client without automatic auth header
+export const client = {
+  get: <T>(url: string, options?: RequestInit) => request<T>('GET', url, options),
+  post: <T>(url: string, body?: unknown, options?: RequestInit) =>
+    request<T>('POST', url, { ...options, body }),
+  put: <T>(url: string, body?: unknown, options?: RequestInit) =>
+    request<T>('PUT', url, { ...options, body }),
+  del: <T>(url: string, options?: RequestInit) => request<T>('DELETE', url, options),
+}
+
+// Hook that injects Authorization header from useAuth
+export function useApiClient() {
+  const { header } = useAuth()
+
+  const withAuth = (options?: RequestInit & { body?: unknown }) => ({
+    ...options,
+    headers: {
+      ...(header ? { Authorization: header } : {}),
+      ...(options?.headers || {}),
+    },
+  })
+
+  return {
+    get: <T>(url: string, options?: RequestInit) =>
+      client.get<T>(url, withAuth(options)),
+    post: <T>(url: string, body?: unknown, options?: RequestInit) =>
+      client.post<T>(url, body, withAuth(options)),
+    put: <T>(url: string, body?: unknown, options?: RequestInit) =>
+      client.put<T>(url, body, withAuth(options)),
+    del: <T>(url: string, options?: RequestInit) =>
+      client.del<T>(url, withAuth(options)),
+  }
+}

--- a/CoShift/frontend/src/feature/admin/AddPersonDialog.tsx
+++ b/CoShift/frontend/src/feature/admin/AddPersonDialog.tsx
@@ -5,7 +5,7 @@ import {
     TextField, FormControl, InputLabel, Select, MenuItem,
     Button
 } from '@mui/material'
-import { useAuth } from '../auth/AuthContext'
+import { useApiClient } from '../../api/client'
 import type { PersonDto } from '../../types/person'
 
 
@@ -17,7 +17,7 @@ interface AddPersonDialogProps {
 }
 
 export default function AddPersonDialog({ open, onClose, onCreated }: AddPersonDialogProps) {
-    const { header } = useAuth()
+    const { post } = useApiClient()
 
     // lokaler Formular-State
     const [nick, setNick] = useState('')
@@ -31,24 +31,17 @@ export default function AddPersonDialog({ open, onClose, onCreated }: AddPersonD
         if (!canSave) return
         setSaving(true)
         try {
-            const res = await fetch('/api/persons', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...(header ? { Authorization: header } : {}),
-                },
-                body: JSON.stringify({ nickname: nick.trim(), password: pass, role }),
+            const created = await post<PersonDto>('/api/persons', {
+                nickname: nick.trim(),
+                password: pass,
+                role,
             })
-            if (!res.ok) throw new Error('Create failed')
-            const created: PersonDto = await res.json()
             onCreated(created)          // 👉 Parent informieren
             onClose()
             // Reset für nächstes Öffnen
             setNick('')
             setPass('')
             setRole('USER')
-        } catch (e) {
-            console.error(e)
         } finally {
             setSaving(false)
         }

--- a/CoShift/frontend/src/feature/admin/EditPersonDialog.tsx
+++ b/CoShift/frontend/src/feature/admin/EditPersonDialog.tsx
@@ -3,8 +3,8 @@ import {
     Dialog, DialogTitle, DialogContent, DialogActions,
     TextField, FormControl, InputLabel, Select, MenuItem, Button
 } from '@mui/material'
-import { useAuth } from '../auth/AuthContext'
-import type {PersonDto} from '../../types/person'
+import { useApiClient } from '../../api/client'
+import type { PersonDto } from '../../types/person'
 
 
 
@@ -17,7 +17,7 @@ export default function EditPersonDialog({
     onClose: () => void
     onUpdated: (p: PersonDto) => void
 }) {
-    const { header } = useAuth()
+    const { put } = useApiClient()
 
     // lokaler Formular-State
     const [nick, setNick] = useState('')
@@ -35,23 +35,17 @@ export default function EditPersonDialog({
 
     const handleSave = async () => {
         if (!person) return
-        const res = await fetch(`/api/persons/${person.id}`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-                ...(header ? { Authorization: header } : {}),
-            },
-            body: JSON.stringify({
+        try {
+            const updated = await put<PersonDto>(`/api/persons/${person.id}`, {
                 nickname: nick.trim(),
                 password: pass.trim() === '' ? null : pass,
                 role,
-            }),
-        })
-        if (res.ok) {
-            const updated = (await res.json()) as PersonDto
+            })
             onUpdated(updated)
             onClose()
-        } else console.error('update failed')
+        } catch (e) {
+            console.error(e)
+        }
     }
 
     return (

--- a/CoShift/frontend/src/feature/week/WeekView.tsx
+++ b/CoShift/frontend/src/feature/week/WeekView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
-import DayCell from './DayCell.tsx'     
-import { useAuth } from '../auth/AuthContext'
+import DayCell from './DayCell.tsx'
 import { Box } from '@mui/material'
+import { useApiClient } from '../../api/client'
 
 export interface ShiftCellVM {
   startTime: string
@@ -13,23 +13,17 @@ export interface DayCellViewModel {
 }
 
 export default function WeekView() {
-  const { header: authHeader } = useAuth()
-  const weeksToShow = 3;
-  const EXPECTED = weeksToShow * 7;
+  const { get } = useApiClient()
+  const weeksToShow = 3
+  const EXPECTED = weeksToShow * 7
 
   const [cells, setCells] = useState<DayCellViewModel[]>([])
 
   useEffect(() => {
-    fetch(`/api/week?count=${weeksToShow}`, {
-      headers: authHeader ? { Authorization: authHeader } : {}
-    })
-      .then(res => {
-        if (!res.ok) throw new Error('Network response was not ok')
-        return res.json()
-      })
-      .then((data: DayCellViewModel[]) => setCells(data))
+    get<DayCellViewModel[]>(`/api/week?count=${weeksToShow}`)
+      .then(data => setCells(data))
       .catch(err => console.error('Failed to load week data', err))
-  }, [authHeader])
+  }, [get])
 
   // Kopfzeile
   const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']


### PR DESCRIPTION
## Summary
- create reusable API client with centralized error handling and automatic auth header injection
- refactor hooks and components to use new client instead of direct fetch
- use client for login and balance calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc7a523cc832d85ffb107240ac340