### PR TITLE
refactor: use auth hook in app context

### DIFF
--- a/CoShift/frontend/src/app/App.tsx
+++ b/CoShift/frontend/src/app/App.tsx
@@ -14,14 +14,14 @@ import useAuth from '../feature/auth/useAuth'
  * – Stellt Routen und den AuthContext bereit.
  */
 export default function App() {
-  const auth = useAuth()
+  const { header, login, balance, logout } = useAuth()
 
   return (
-    <AuthContext.Provider value={auth}>
-      {auth.header && <Layout />}
+    <AuthContext.Provider value={{ header, balance, logout }}>
+      {header && <Layout />}
 
-      {!auth.header ? (
-        <Login onLogin={auth.login} />
+      {!header ? (
+        <Login onLogin={login} />
       ) : (
         <Routes>
           <Route element={<PrivateLayout />}>

--- a/CoShift/frontend/src/feature/auth/AuthContext.tsx
+++ b/CoShift/frontend/src/feature/auth/AuthContext.tsx
@@ -1,7 +1,11 @@
 import { createContext, useContext } from 'react'
-import type useAuth from './useAuth'
 
-export type AuthCtx = ReturnType<typeof useAuth>
+export interface AuthCtx {
+  header: string | null
+  balance: number | null
+  logout: () => void
+}
+
 export const AuthContext = createContext<AuthCtx | null>(null)
 export const useAuth = () => {
   const ctx = useContext(AuthContext)

--- a/CoShift/frontend/src/feature/week/WeekView.tsx
+++ b/CoShift/frontend/src/feature/week/WeekView.tsx
@@ -1,6 +1,6 @@
 import DayCell from './DayCell.tsx'
 import { Box } from '@mui/material'
-import { useWeek, DayCellViewModel } from './hooks/useWeek'
+import { useWeek, type DayCellViewModel } from './hooks/useWeek'
 
 export default function WeekView() {
   const weeksToShow = 3

--- a/CoShift/frontend/src/feature/week/hooks/useWeek.ts
+++ b/CoShift/frontend/src/feature/week/hooks/useWeek.ts
@@ -10,7 +10,10 @@ export interface DayCellViewModel {
   shifts: ShiftCellVM[]
 }
 
-async function fetchWeek(weeksToShow: number, header?: string): Promise<DayCellViewModel[]> {
+async function fetchWeek(
+  weeksToShow: number,
+  header?: string | null
+): Promise<DayCellViewModel[]> {
   const res = await fetch(`/api/week?count=${weeksToShow}`, {
     headers: header ? { Authorization: header } : {},
   })


### PR DESCRIPTION
## Summary
- simplify App by using `useAuth` hook and exposing its header, balance and logout through `AuthContext`
- align AuthContext type with simplified auth shape
- fix WeekView and useWeek typings so build passes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dcb8435e4832dbcd7fe32e3584bd1