### PR TITLE
Refactor login form to use Material UI components

### DIFF
--- a/CoShift/frontend/src/app/App.css
+++ b/CoShift/frontend/src/app/App.css
@@ -68,5 +68,4 @@
   border-radius: 4px;
 }
 
-.login-form input { margin: 0.25rem; }
 

--- a/CoShift/frontend/src/feature/auth/LoginForm.tsx
+++ b/CoShift/frontend/src/feature/auth/LoginForm.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from 'react'
+import { Box, TextField, Button, Alert } from '@mui/material'
 
 interface Props {
   /* Liefert true bei erfolgreichem Login, sonst false */
@@ -22,23 +23,35 @@ export default function Login({ onLogin }: Props) {
   }
 
   return (
-    <form onSubmit={submit} className="login-form">
-      <input
+    <Box
+      component="form"
+      onSubmit={submit}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        width: 300,
+        mx: 'auto',
+        mt: 8,
+      }}
+    >
+      <TextField
+        label="User"
         value={user}
         onChange={e => setUser(e.target.value)}
-        placeholder="User"
         autoComplete="username"
+        fullWidth
       />
-      <input
+      <TextField
+        label="Password"
         type="password"
         value={pass}
         onChange={e => setPass(e.target.value)}
-        placeholder="Password"
         autoComplete="current-password"
+        fullWidth
       />
-      <button type="submit">Login</button>
-
-      {error && <div className="error-msg">{error}</div>}
-    </form>
+      {error && <Alert severity="error">{error}</Alert>}
+      <Button type="submit" variant="contained">Login</Button>
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary
- replace plain HTML login form with MUI TextField, Button, and Alert for consistent styling
- remove obsolete CSS for legacy login form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dd0188904832d9492a46114ad2009