### PR TITLE
Format balance as hours and minutes

### DIFF
--- a/CoShift/frontend/src/layout/Layout.tsx
+++ b/CoShift/frontend/src/layout/Layout.tsx
@@ -7,6 +7,12 @@ import LogoutIcon    from '@mui/icons-material/Logout'
 import { Link as RouterLink, useLocation } from 'react-router-dom'
 import { useAuth }   from '../feature/auth/AuthContext'
 
+function formatMinutes(total: number): string {
+  const hours = Math.floor(total / 60)
+  const minutes = total % 60
+  return `${hours}h ${minutes}m`
+}
+
 export default function Layout(){
   const [open,setOpen]=useState(false)
   const { logout, balance } = useAuth()
@@ -21,7 +27,9 @@ export default function Layout(){
             <MenuIcon/>
           </IconButton>
           <Typography sx={{flexGrow:1}} variant="h6">CoShift</Typography>
-          {balance!==null && <Typography sx={{mr:2}}>{balance} min</Typography>}
+          {balance!==null && (
+            <Typography sx={{ mr: 2 }}>{formatMinutes(balance)}</Typography>
+          )}
           <Button color="inherit" startIcon={<LogoutIcon/>} onClick={logout}>Logout</Button>
         </Toolbar>
       </AppBar>


### PR DESCRIPTION
## Summary
- format time account in the app bar to show hours and minutes instead of raw minutes, improving readability

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dd1aa8180832d88bfeb41861ce612