### PR TITLE
Refactor frontend API usage

### DIFF
--- a/CoShift/frontend/src/api.ts
+++ b/CoShift/frontend/src/api.ts
@@ -1,0 +1,41 @@
+import { useAuth } from './feature/auth/AuthContext'
+import { useCallback, useMemo } from 'react'
+
+// Hook providing helper functions for HTTP calls with optional auth header
+export function useApi() {
+  const { header } = useAuth()
+
+  const request = useCallback(async <T>(url: string, init: RequestInit = {}): Promise<T> => {
+    const headers: HeadersInit = {
+      ...(init.headers || {}),
+      ...(header ? { Authorization: header } : {}),
+    }
+
+    const res = await fetch(url, { ...init, headers })
+    if (!res.ok) throw new Error('Network error')
+
+    if (res.status === 204) {
+      // no content
+      return undefined as T
+    }
+
+    return res.json() as Promise<T>
+  }, [header])
+
+  return useMemo(() => ({
+    get: <T>(url: string) => request<T>(url),
+    post: <T>(url: string, body: unknown) =>
+      request<T>(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+    put: <T>(url: string, body: unknown) =>
+      request<T>(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+    del: <T>(url: string) => request<T>(url, { method: 'DELETE' }),
+  }), [request])
+}

--- a/CoShift/frontend/src/feature/admin/AddPersonDialog.tsx
+++ b/CoShift/frontend/src/feature/admin/AddPersonDialog.tsx
@@ -5,8 +5,8 @@ import {
     TextField, FormControl, InputLabel, Select, MenuItem,
     Button
 } from '@mui/material'
-import { useAuth } from '../auth/AuthContext'
 import type { PersonDto } from '../../types/person'
+import { useApi } from '../../api'
 
 
 
@@ -17,7 +17,7 @@ interface AddPersonDialogProps {
 }
 
 export default function AddPersonDialog({ open, onClose, onCreated }: AddPersonDialogProps) {
-    const { header } = useAuth()
+    const api = useApi()
 
     // lokaler Formular-State
     const [nick, setNick] = useState('')
@@ -31,16 +31,11 @@ export default function AddPersonDialog({ open, onClose, onCreated }: AddPersonD
         if (!canSave) return
         setSaving(true)
         try {
-            const res = await fetch('/api/persons', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...(header ? { Authorization: header } : {}),
-                },
-                body: JSON.stringify({ nickname: nick.trim(), password: pass, role }),
+            const created = await api.post<PersonDto>('/api/persons', {
+                nickname: nick.trim(),
+                password: pass,
+                role,
             })
-            if (!res.ok) throw new Error('Create failed')
-            const created: PersonDto = await res.json()
             onCreated(created)          // 👉 Parent informieren
             onClose()
             // Reset für nächstes Öffnen

--- a/CoShift/frontend/src/feature/admin/EditPersonDialog.tsx
+++ b/CoShift/frontend/src/feature/admin/EditPersonDialog.tsx
@@ -3,8 +3,8 @@ import {
     Dialog, DialogTitle, DialogContent, DialogActions,
     TextField, FormControl, InputLabel, Select, MenuItem, Button
 } from '@mui/material'
-import { useAuth } from '../auth/AuthContext'
-import type {PersonDto} from '../../types/person'
+import type { PersonDto } from '../../types/person'
+import { useApi } from '../../api'
 
 
 
@@ -17,7 +17,7 @@ export default function EditPersonDialog({
     onClose: () => void
     onUpdated: (p: PersonDto) => void
 }) {
-    const { header } = useAuth()
+    const api = useApi()
 
     // lokaler Formular-State
     const [nick, setNick] = useState('')
@@ -35,23 +35,17 @@ export default function EditPersonDialog({
 
     const handleSave = async () => {
         if (!person) return
-        const res = await fetch(`/api/persons/${person.id}`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-                ...(header ? { Authorization: header } : {}),
-            },
-            body: JSON.stringify({
+        try {
+            const updated = await api.put<PersonDto>(`/api/persons/${person.id}`, {
                 nickname: nick.trim(),
                 password: pass.trim() === '' ? null : pass,
                 role,
-            }),
-        })
-        if (res.ok) {
-            const updated = (await res.json()) as PersonDto
+            })
             onUpdated(updated)
             onClose()
-        } else console.error('update failed')
+        } catch (err) {
+            console.error('update failed', err)
+        }
     }
 
     return (

--- a/CoShift/frontend/src/feature/week/WeekView.tsx
+++ b/CoShift/frontend/src/feature/week/WeekView.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
-import DayCell from './DayCell.tsx'     
-import { useAuth } from '../auth/AuthContext'
+import DayCell from './DayCell.tsx'
 import { Box } from '@mui/material'
+import { useApi } from '../../api'
+import { useQuery } from '@tanstack/react-query'
 
 export interface ShiftCellVM {
   startTime: string
@@ -13,29 +13,19 @@ export interface DayCellViewModel {
 }
 
 export default function WeekView() {
-  const { header: authHeader } = useAuth()
-  const weeksToShow = 3;
-  const EXPECTED = weeksToShow * 7;
+  const api = useApi()
+  const weeksToShow = 3
+  const EXPECTED = weeksToShow * 7
 
-  const [cells, setCells] = useState<DayCellViewModel[]>([])
-
-  useEffect(() => {
-    fetch(`/api/week?count=${weeksToShow}`, {
-      headers: authHeader ? { Authorization: authHeader } : {}
-    })
-      .then(res => {
-        if (!res.ok) throw new Error('Network response was not ok')
-        return res.json()
-      })
-      .then((data: DayCellViewModel[]) => setCells(data))
-      .catch(err => console.error('Failed to load week data', err))
-  }, [authHeader])
+  const { data: cells = [] } = useQuery({
+    queryKey: ['week', weeksToShow],
+    queryFn: () => api.get<DayCellViewModel[]>(`/api/week?count=${weeksToShow}`),
+  })
 
   // Kopfzeile
   const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']
 
   // Fallback: solange noch keine Daten da sind, leere Zellen anzeigen
-  // test
   const empty: DayCellViewModel = { shifts: [] }
   const display = cells.length === EXPECTED
     ? cells


### PR DESCRIPTION
## Summary
- add `useApi` hook to centralize authenticated fetch logic
- refactor week view and admin dialogs to use new API helper and React Query

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `mvn -q test` (fails: Non-resolvable parent POM: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_688dd2c931cc832da35d294640bc57bc