### PR TITLE
refactor auth and simplify navigation

### DIFF
--- a/CoShift/frontend/src/app/App.tsx
+++ b/CoShift/frontend/src/app/App.tsx
@@ -1,4 +1,3 @@
-import { useState, useCallback, useEffect } from 'react'
 import './App.css'
 import Login       from '../feature/auth/LoginForm'
 import WeekView    from '../feature/week/WeekView'
@@ -6,78 +5,18 @@ import Layout      from '../layout/Layout'
 import PrivateLayout from '../layout/PrivateLayout'
 import { AuthContext } from '../feature/auth/AuthContext'
 import { Routes, Route, Navigate } from 'react-router-dom'
-import AdminPage   from '../feature/admin/AdminPage'   // gleich anlegen, siehe unten
+import AdminPage   from '../feature/admin/AdminPage'
+import { useAuthProvider } from '../feature/auth/useAuthProvider'
 
-/**
- * Root-Komponente:
- * – Verwaltet den Auth-Header im State.
- * – Reicht eine „tryLogin“-Funktion an <Login/> durch, die
- *   einen Probe-Call auf ein geschütztes Backend-API macht.
- * – Zeigt nach erfolgreichem Login die <WeekView/>.
- */
 export default function App() {
-  const [authHeader, setAuthHeader] = useState<string | null>(null)
-  const [balance,    setBalance]    = useState<number | null>(null)
-
-
-
-  const tryLogin = useCallback(async (header: string): Promise<boolean> => {
-    try {
-      const res = await fetch('/api/shifts', {
-        headers: { Authorization: header }
-      })
-
-      if (res.ok) {
-        setAuthHeader(header)
-        sessionStorage.setItem('authHeader', header)
-
-        // Saldo laden
-        try {
-          const balRes = await fetch('/api/persons/me/timeaccount', {
-            headers: { Authorization: header }
-          })
-          if (balRes.ok) {
-            const dto = await balRes.json() as { balanceInMinutes: number }
-            setBalance(dto.balanceInMinutes)
-          }
-        } catch (e) {
-          console.error('Unable to fetch balance', e)
-        }
-
-        return true
-      }
-    } catch {
-      console.error('Api unavailable')
-    }
-    sessionStorage.removeItem('authHeader')
-    return false                         // 401 
-  }, [])
-
-  function logout() {
-    setAuthHeader(null)
-    setBalance(null)
-    sessionStorage.removeItem('authHeader')        
-  }
-
-  useEffect(() => {
-    const stored = sessionStorage.getItem('authHeader')
-    if (stored) {
-      // Schnelltest: ist das Token noch gültig?
-      tryLogin(stored).catch(() => {
-        sessionStorage.removeItem('authHeader')
-      })
-    }
-  }, [tryLogin])
-  
-
-
+  const auth = useAuthProvider()
 
   return (
-    <AuthContext.Provider value={{ header: authHeader, balance, logout }}>
-      {authHeader && <Layout />}          {/* <- MUI-AppBar inkl. Burger */}
+    <AuthContext.Provider value={auth}>
+      {auth.header && <Layout />}
 
-      {!authHeader ? (
-        <Login onLogin={tryLogin} />
+      {!auth.header ? (
+        <Login />
       ) : (
         <Routes>
           <Route element={<PrivateLayout />}>

--- a/CoShift/frontend/src/feature/auth/AuthContext.tsx
+++ b/CoShift/frontend/src/feature/auth/AuthContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react'
 export interface AuthCtx {
   header:  string | null
   balance: number | null
+  login:   (authHeader: string) => Promise<boolean>
   logout: () => void
 }
 export const AuthContext = createContext<AuthCtx | null>(null)

--- a/CoShift/frontend/src/feature/auth/LoginForm.tsx
+++ b/CoShift/frontend/src/feature/auth/LoginForm.tsx
@@ -1,21 +1,18 @@
 import { useState, type FormEvent } from 'react'
 import { Box, TextField, Button, Alert } from '@mui/material'
+import { useAuth } from './AuthContext'
 
-interface Props {
-  /* Liefert true bei erfolgreichem Login, sonst false */
-  onLogin: (authHeader: string) => Promise<boolean>
-}
-
-export default function Login({ onLogin }: Props) {
+export default function Login() {
   const [user,  setUser]  = useState('')
   const [pass,  setPass]  = useState('')
   const [error, setError] = useState<string | null>(null)
+  const { login } = useAuth()
 
   async function submit(e: FormEvent) {
     e.preventDefault()
     setError(null)                               // alte Fehlermeldung zurücksetzen
     const token   = btoa(`${user}:${pass}`)
-    const success = await onLogin(`Basic ${token}`)
+    const success = await login(`Basic ${token}`)
 
     if (!success) {
       setError('Benutzername oder Passwort falsch')

--- a/CoShift/frontend/src/feature/auth/useAuthProvider.ts
+++ b/CoShift/frontend/src/feature/auth/useAuthProvider.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react'
+
+interface BalanceDto {
+  balanceInMinutes: number
+}
+
+export function useAuthProvider() {
+  const [header, setHeader]   = useState<string | null>(null)
+  const [balance, setBalance] = useState<number | null>(null)
+
+  const login = useCallback(async (authHeader: string): Promise<boolean> => {
+    try {
+      const res = await fetch('/api/shifts', {
+        headers: { Authorization: authHeader }
+      })
+      if (!res.ok) throw new Error('unauthorized')
+
+      setHeader(authHeader)
+      sessionStorage.setItem('authHeader', authHeader)
+
+      try {
+        const balRes = await fetch('/api/persons/me/timeaccount', {
+          headers: { Authorization: authHeader }
+        })
+        if (balRes.ok) {
+          const dto = await balRes.json() as BalanceDto
+          setBalance(dto.balanceInMinutes)
+        }
+      } catch (e) {
+        console.error('Unable to fetch balance', e)
+      }
+      return true
+    } catch {
+      sessionStorage.removeItem('authHeader')
+      return false
+    }
+  }, [])
+
+  const logout = useCallback(() => {
+    setHeader(null)
+    setBalance(null)
+    sessionStorage.removeItem('authHeader')
+  }, [])
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('authHeader')
+    if (stored) {
+      login(stored).catch(() => sessionStorage.removeItem('authHeader'))
+    }
+  }, [login])
+
+  return { header, balance, login, logout }
+}

--- a/CoShift/frontend/src/feature/week/WeekView.tsx
+++ b/CoShift/frontend/src/feature/week/WeekView.tsx
@@ -1,5 +1,5 @@
 import DayCell from './DayCell.tsx'
-import { Box } from '@mui/material'
+import { Box, CircularProgress } from '@mui/material'
 import { useApi } from '../../api'
 import { useQuery } from '@tanstack/react-query'
 
@@ -14,22 +14,24 @@ export interface DayCellViewModel {
 
 export default function WeekView() {
   const api = useApi()
-  const weeksToShow = 3
-  const EXPECTED = weeksToShow * 7
 
-  const { data: cells = [] } = useQuery({
-    queryKey: ['week', weeksToShow],
-    queryFn: () => api.get<DayCellViewModel[]>(`/api/week?count=${weeksToShow}`),
+  const { data: cells, isLoading } = useQuery({
+    queryKey: ['week'],
+    queryFn: () => api.get<DayCellViewModel[]>(`/api/week?count=1`),
   })
 
   // Kopfzeile
   const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']
 
-  // Fallback: solange noch keine Daten da sind, leere Zellen anzeigen
-  const empty: DayCellViewModel = { shifts: [] }
-  const display = cells.length === EXPECTED
-    ? cells
-    : Array.from({ length: EXPECTED }, () => empty)
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  const display = (cells ?? Array.from({ length: 7 }, () => ({ shifts: [] })) ) as DayCellViewModel[]
 
   return (
     <Box

--- a/CoShift/frontend/src/layout/Layout.tsx
+++ b/CoShift/frontend/src/layout/Layout.tsx
@@ -1,8 +1,4 @@
-import { useState } from 'react'
-import { AppBar, Toolbar, IconButton, Typography, Drawer, List, ListItemButton, ListItemIcon, ListItemText, Box, Button } from '@mui/material'
-import MenuIcon      from '@mui/icons-material/Menu'
-import HomeIcon      from '@mui/icons-material/Home'
-import AdminPanelIcon from '@mui/icons-material/AdminPanelSettings'
+import { AppBar, Toolbar, Typography, Button } from '@mui/material'
 import LogoutIcon    from '@mui/icons-material/Logout'
 import { Link as RouterLink, useLocation } from 'react-router-dom'
 import { useAuth }   from '../feature/auth/AuthContext'
@@ -14,44 +10,29 @@ function formatMinutes(total: number): string {
 }
 
 export default function Layout(){
-  const [open,setOpen]=useState(false)
   const { logout, balance } = useAuth()
   const loc = useLocation()
 
   return (
     <>
-      {/* Header */}
       <AppBar position="fixed">
         <Toolbar>
-          <IconButton color="inherit" edge="start" onClick={()=>setOpen(true)}>
-            <MenuIcon/>
-          </IconButton>
-          <Typography sx={{flexGrow:1}} variant="h6">CoShift</Typography>
-          {balance!==null && (
-            <Typography sx={{ mr: 2 }}>{formatMinutes(balance)}</Typography>
+          <Typography sx={{ flexGrow: 1 }} variant="h6">CoShift</Typography>
+          <Button color="inherit" component={RouterLink} to="/" disabled={loc.pathname === '/'}>
+            Übersicht
+          </Button>
+          <Button color="inherit" component={RouterLink} to="/admin" disabled={loc.pathname === '/admin'}>
+            Admin
+          </Button>
+          {balance !== null && (
+            <Typography sx={{ mx: 2 }}>{formatMinutes(balance)}</Typography>
           )}
-          <Button color="inherit" startIcon={<LogoutIcon/>} onClick={logout}>Logout</Button>
+          <Button color="inherit" startIcon={<LogoutIcon />} onClick={logout}>Logout</Button>
         </Toolbar>
       </AppBar>
-
-      {/* Drawer */}
-      <Drawer open={open} onClose={()=>setOpen(false)}>
-        <Box sx={{width:240}} role="presentation" onClick={()=>setOpen(false)}>
-          <List>
-            <ListItemButton component={RouterLink} to="/" selected={loc.pathname==='/'}>
-              <ListItemIcon><HomeIcon/></ListItemIcon>
-              <ListItemText primary="Übersicht"/>
-            </ListItemButton>
-            <ListItemButton component={RouterLink} to="/admin" selected={loc.pathname==='/admin'}>
-              <ListItemIcon><AdminPanelIcon/></ListItemIcon>
-              <ListItemText primary="Admin"/>
-            </ListItemButton>
-          </List>
-        </Box>
-      </Drawer>
 
       {/* Platz für Inhalt unter der AppBar */}
       <Toolbar/>  {/* push content under fixed AppBar */}
     </>
   )
-} 
+}


### PR DESCRIPTION
## Summary
- encapsulate login logic in `useAuthProvider` and extend auth context
- simplify navigation to top bar buttons and remove drawer
- show loading spinner and only one week in schedule

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688dd5786554832daef5262567f32bc8