### PR TITLE
refactor: move admin and week pages

### DIFF
--- a/CoShift/frontend/src/app/App.tsx
+++ b/CoShift/frontend/src/app/App.tsx
@@ -1,19 +1,19 @@
 import { useState, useCallback, useEffect } from 'react'
 import './App.css'
 import Login       from '../features/auth/components/LoginForm'
-import WeekView    from '../features/week/components/WeekView'
+import WeekPage    from '../pages/WeekPage'
 import Layout      from '../layout/Layout'
 import PrivateLayout from '../layout/PrivateLayout'
 import { AuthContext } from '../features/auth/hooks/AuthContext'
 import { Routes, Route, Navigate } from 'react-router-dom'
-import AdminPage   from '../features/admin/components/AdminPage'   // gleich anlegen, siehe unten
+import AdminPage   from '../pages/AdminPage'
 
 /**
  * Root-Komponente:
  * – Verwaltet den Auth-Header im State.
  * – Reicht eine „tryLogin“-Funktion an <Login/> durch, die
  *   einen Probe-Call auf ein geschütztes Backend-API macht.
- * – Zeigt nach erfolgreichem Login die <WeekView/>.
+ * – Zeigt nach erfolgreichem Login die <WeekPage/>.
  */
 export default function App() {
   const [authHeader, setAuthHeader] = useState<string | null>(null)
@@ -81,7 +81,7 @@ export default function App() {
       ) : (
         <Routes>
           <Route element={<PrivateLayout />}>
-            <Route path="/"      element={<WeekView />} />
+            <Route path="/"      element={<WeekPage />} />
             <Route path="/admin" element={<AdminPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/" />} />

--- a/CoShift/frontend/src/pages/AdminPage.tsx
+++ b/CoShift/frontend/src/pages/AdminPage.tsx
@@ -1,4 +1,3 @@
-// src/pages/AdminPage.tsx
 import { useState } from 'react'
 import {
     Container,
@@ -19,10 +18,10 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import AddIcon from '@mui/icons-material/Add'
 import { IconButton as MuiIconButton } from '@mui/material'
 
-import AddPersonDialog from './AddPersonDialog'
-import EditPersonDialog from './EditPersonDialog'
-import { usePersons } from '../hooks/usePersons'
-import type { PersonDto } from '../../../types/person'
+import AddPersonDialog from '../features/admin/components/AddPersonDialog'
+import EditPersonDialog from '../features/admin/components/EditPersonDialog'
+import { usePersons } from '../features/admin/hooks/usePersons'
+import type { PersonDto } from '../types/person'
 
 export default function AdminPage() {
     const {

--- a/CoShift/frontend/src/pages/WeekPage.tsx
+++ b/CoShift/frontend/src/pages/WeekPage.tsx
@@ -1,10 +1,10 @@
-import DayCell from './DayCell'
+import DayCell from '../features/week/components/DayCell'
 import { Box } from '@mui/material'
-import { useApi } from '../../../api'
+import { useApi } from '../api'
 import { useQuery } from '@tanstack/react-query'
-import type { DayCellViewModel } from '../types'
+import type { DayCellViewModel } from '../features/week/types'
 
-export default function WeekView() {
+export default function WeekPage() {
   const api = useApi()
   const weeksToShow = 3
   const EXPECTED = weeksToShow * 7


### PR DESCRIPTION
## Summary
- create AdminPage and WeekPage under src/pages and move existing code
- update App routing to import pages

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688de461cc54832da05d17c2074038ce