### PR TITLE
feat: centralize auth handling with provider

### DIFF
--- a/CoShift/frontend/src/app/App.tsx
+++ b/CoShift/frontend/src/app/App.tsx
@@ -1,82 +1,21 @@
-import { useState, useCallback, useEffect } from 'react'
 import './App.css'
 import Login       from '../features/auth/components/LoginForm'
 import WeekPage    from '../pages/WeekPage'
 import Layout      from '../layout/Layout'
 import PrivateLayout from '../layout/PrivateLayout'
-import { AuthContext } from '../features/auth/hooks/AuthContext'
 import { Routes, Route, Navigate } from 'react-router-dom'
 import AdminPage   from '../pages/AdminPage'
+import { AuthProvider } from '../features/auth/AuthProvider'
+import { useAuth } from '../features/auth/hooks/AuthContext'
 
-/**
- * Root-Komponente:
- * – Verwaltet den Auth-Header im State.
- * – Reicht eine „tryLogin“-Funktion an <Login/> durch, die
- *   einen Probe-Call auf ein geschütztes Backend-API macht.
- * – Zeigt nach erfolgreichem Login die <WeekPage/>.
- */
-export default function App() {
-  const [authHeader, setAuthHeader] = useState<string | null>(null)
-  const [balance,    setBalance]    = useState<number | null>(null)
-
-
-
-  const tryLogin = useCallback(async (header: string): Promise<boolean> => {
-    try {
-      const res = await fetch('/api/shifts', {
-        headers: { Authorization: header }
-      })
-
-      if (res.ok) {
-        setAuthHeader(header)
-        sessionStorage.setItem('authHeader', header)
-
-        // Saldo laden
-        try {
-          const balRes = await fetch('/api/persons/me/timeaccount', {
-            headers: { Authorization: header }
-          })
-          if (balRes.ok) {
-            const dto = await balRes.json() as { balanceInMinutes: number }
-            setBalance(dto.balanceInMinutes)
-          }
-        } catch (e) {
-          console.error('Unable to fetch balance', e)
-        }
-
-        return true
-      }
-    } catch {
-      console.error('Api unavailable')
-    }
-    sessionStorage.removeItem('authHeader')
-    return false                         // 401 
-  }, [])
-
-  function logout() {
-    setAuthHeader(null)
-    setBalance(null)
-    sessionStorage.removeItem('authHeader')        
-  }
-
-  useEffect(() => {
-    const stored = sessionStorage.getItem('authHeader')
-    if (stored) {
-      // Schnelltest: ist das Token noch gültig?
-      tryLogin(stored).catch(() => {
-        sessionStorage.removeItem('authHeader')
-      })
-    }
-  }, [tryLogin])
-  
-
-
+function Routing() {
+  const { header, tryLogin } = useAuth()
 
   return (
-    <AuthContext.Provider value={{ header: authHeader, balance, logout }}>
-      {authHeader && <Layout />}          {/* <- MUI-AppBar inkl. Burger */}
+    <>
+      {header && <Layout />}
 
-      {!authHeader ? (
+      {!header ? (
         <Login onLogin={tryLogin} />
       ) : (
         <Routes>
@@ -87,6 +26,14 @@ export default function App() {
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>
       )}
-    </AuthContext.Provider>
+    </>
+  )
+}
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <Routing />
+    </AuthProvider>
   )
 }

--- a/CoShift/frontend/src/features/auth/AuthProvider.tsx
+++ b/CoShift/frontend/src/features/auth/AuthProvider.tsx
@@ -1,0 +1,61 @@
+/* eslint react-refresh/only-export-components: "off" */
+import { createContext, useCallback, useEffect, useState, type ReactNode } from 'react'
+import type { AuthCtx } from './types'
+
+export const AuthContext = createContext<AuthCtx | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [header, setHeader]   = useState<string | null>(null)
+  const [balance, setBalance] = useState<number | null>(null)
+
+  const tryLogin = useCallback(async (authHeader: string): Promise<boolean> => {
+    try {
+      const res = await fetch('/api/shifts', {
+        headers: { Authorization: authHeader }
+      })
+
+      if (res.ok) {
+        setHeader(authHeader)
+        sessionStorage.setItem('authHeader', authHeader)
+
+        try {
+          const balRes = await fetch('/api/persons/me/timeaccount', {
+            headers: { Authorization: authHeader }
+          })
+          if (balRes.ok) {
+            const dto = await balRes.json() as { balanceInMinutes: number }
+            setBalance(dto.balanceInMinutes)
+          }
+        } catch (e) {
+          console.error('Unable to fetch balance', e)
+        }
+        return true
+      }
+    } catch {
+      console.error('Api unavailable')
+    }
+    sessionStorage.removeItem('authHeader')
+    return false
+  }, [])
+
+  function logout() {
+    setHeader(null)
+    setBalance(null)
+    sessionStorage.removeItem('authHeader')
+  }
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('authHeader')
+    if (stored) {
+      tryLogin(stored).catch(() => {
+        sessionStorage.removeItem('authHeader')
+      })
+    }
+  }, [tryLogin])
+
+  return (
+    <AuthContext.Provider value={{ header, balance, tryLogin, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/CoShift/frontend/src/features/auth/hooks/AuthContext.tsx
+++ b/CoShift/frontend/src/features/auth/hooks/AuthContext.tsx
@@ -1,9 +1,9 @@
-import { createContext, useContext } from 'react'
+import { useContext } from 'react'
+import { AuthContext } from '../AuthProvider'
 import type { AuthCtx } from '../types'
 
-export const AuthContext = createContext<AuthCtx | null>(null)
 export const useAuth = () => {
-  const ctx = useContext(AuthContext)
-  if (!ctx) throw new Error('useAuth must be inside <AuthContext.Provider>')
+  const ctx = useContext<AuthCtx | null>(AuthContext)
+  if (!ctx) throw new Error('useAuth must be inside <AuthProvider>')
   return ctx
 }

--- a/CoShift/frontend/src/features/auth/types/index.ts
+++ b/CoShift/frontend/src/features/auth/types/index.ts
@@ -1,5 +1,6 @@
 export interface AuthCtx {
   header: string | null
   balance: number | null
+  tryLogin: (authHeader: string) => Promise<boolean>
   logout: () => void
 }


### PR DESCRIPTION
## Summary
- add AuthProvider to manage auth state and token persistence
- simplify App to use AuthProvider and handle only routing
- update auth hook and types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688deabb7470832d9c137a72ea5f1606