### PR TITLE
Add day view and navigation from week view

### DIFF
--- a/CoShift/frontend/src/app/App.tsx
+++ b/CoShift/frontend/src/app/App.tsx
@@ -3,6 +3,7 @@ import Login            from '../features/auth/components/LoginForm'
 import PrivateLayout    from '../layout/PrivateLayout'
 import RequireAdmin     from '../layout/RequireAdmin'
 import WeekPage         from '../pages/weekPage/WeekPage.tsx'
+import DayPage          from '../pages/dayPage/DayPage.tsx'
 import AdminPage        from '../pages/adminPage/AdminPage.tsx'
 import { AuthProvider, useAuth } from '../features/auth/AuthProvider'
 
@@ -16,6 +17,7 @@ function Routing() {
         <Routes>
           <Route element={<PrivateLayout />}>
             <Route path="/" element={<WeekPage />} />
+            <Route path="day/:date" element={<DayPage />} />
             <Route element={<RequireAdmin />}>           {/* ⬅︎ Guard */}
               <Route path="admin" element={<AdminPage />} />
             </Route>

--- a/CoShift/frontend/src/pages/dayPage/DayPage.tsx
+++ b/CoShift/frontend/src/pages/dayPage/DayPage.tsx
@@ -1,0 +1,99 @@
+import { Box } from '@mui/material'
+import { useParams } from 'react-router-dom'
+import { useApi } from '../api.ts'
+import { useQuery } from '@tanstack/react-query'
+
+interface ShiftPerson {
+  id: number
+  nickname: string
+  role: string
+}
+
+interface ShiftDetail {
+  id: number
+  startTime: string
+  durationInMinutes: number
+  capacity: number
+  persons: ShiftPerson[]
+}
+
+export default function DayPage() {
+  const { date = '' } = useParams<{ date: string }>()
+  const api = useApi()
+
+  const { data: shifts = [] } = useQuery({
+    queryKey: ['day', date],
+    queryFn: () => api.get<ShiftDetail[]>(`/api/shifts/day?date=${date}`),
+    enabled: !!date,
+  })
+
+  const startHour = 6
+  const endHour = 22
+  const hourHeight = 50
+  const pxPerMinute = hourHeight / 60
+  const totalHours = endHour - startHour
+  const containerHeight = totalHours * hourHeight
+
+  return (
+    <Box sx={{ display: 'grid', gridTemplateColumns: '4rem 1fr' }}>
+      <Box sx={{ position: 'relative', height: containerHeight }}>
+        {Array.from({ length: totalHours + 1 }).map((_, i) => (
+          <Box
+            key={i}
+            sx={{
+              position: 'absolute',
+              top: i * hourHeight,
+              height: hourHeight,
+              borderTop: 1,
+              borderColor: 'divider',
+              fontSize: '0.75rem',
+            }}
+          >
+            {(startHour + i).toString().padStart(2, '0')}:00
+          </Box>
+        ))}
+      </Box>
+      <Box sx={{ position: 'relative', height: containerHeight, borderLeft: 1, borderColor: 'divider' }}>
+        {Array.from({ length: totalHours + 1 }).map((_, i) => (
+          <Box
+            key={i}
+            sx={{
+              position: 'absolute',
+              top: i * hourHeight,
+              left: 0,
+              right: 0,
+              borderTop: 1,
+              borderColor: 'divider',
+            }}
+          />
+        ))}
+        {shifts.map(shift => {
+          const start = new Date(shift.startTime)
+          const startMinutes = start.getHours() * 60 + start.getMinutes()
+          const top = (startMinutes - startHour * 60) * pxPerMinute
+          const height = shift.durationInMinutes * pxPerMinute
+          const names = shift.persons.map(p => p.nickname).join(', ')
+          return (
+            <Box
+              key={shift.id}
+              sx={{
+                position: 'absolute',
+                top,
+                height,
+                left: 0,
+                right: 0,
+                bgcolor: 'secondary.main',
+                color: 'secondary.contrastText',
+                borderRadius: 1,
+                p: 0.5,
+                overflow: 'hidden',
+              }}
+            >
+              {names || 'frei'}
+            </Box>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}

--- a/CoShift/frontend/src/pages/weekPage/WeekPage.tsx
+++ b/CoShift/frontend/src/pages/weekPage/WeekPage.tsx
@@ -18,7 +18,7 @@ export default function WeekPage() {
   const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']
 
   // Fallback: solange noch keine Daten da sind, leere Zellen anzeigen
-  const empty: DayCellViewModel = { shifts: [] }
+  const empty: DayCellViewModel = { date: '', shifts: [] }
   const display = cells.length === EXPECTED
     ? cells
     : Array.from({ length: EXPECTED }, () => empty)

--- a/CoShift/frontend/src/pages/weekPage/components/DayCell.tsx
+++ b/CoShift/frontend/src/pages/weekPage/components/DayCell.tsx
@@ -1,10 +1,15 @@
 import { Box } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
 import type { DayCellViewModel } from '../types/dayCellView.ts'
 
 export default function DayCell({ cell }: { cell: DayCellViewModel }) {
+  const navigate = useNavigate()
 
   return (
-    <Box sx={{ minHeight: '4rem', border: 1, borderColor: 'divider' }}>
+    <Box
+      sx={{ minHeight: '4rem', border: 1, borderColor: 'divider', cursor: 'pointer' }}
+      onClick={() => cell.date && navigate(`/day/${cell.date}`)}
+    >
       {cell.shifts.length === 0 && (
         <Box sx={{ opacity: 0.3 }}>&nbsp;</Box>
       )}

--- a/CoShift/frontend/src/pages/weekPage/types/dayCellView.ts
+++ b/CoShift/frontend/src/pages/weekPage/types/dayCellView.ts
@@ -4,5 +4,6 @@ export interface ShiftCellVM {
 }
 
 export interface DayCellViewModel {
+  date: string
   shifts: ShiftCellVM[]
 }

--- a/CoShift/src/main/java/org/coshift/c_adapters/presentation/DayCellViewModel.java
+++ b/CoShift/src/main/java/org/coshift/c_adapters/presentation/DayCellViewModel.java
@@ -1,11 +1,12 @@
 package org.coshift.c_adapters.presentation;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
  * Container für alle Schichten eines Tages.
  */
-public record DayCellViewModel(List<ShiftCellViewModel> shifts) {}
+public record DayCellViewModel(LocalDate date, List<ShiftCellViewModel> shifts) {}
 
 /**
  * Einzelne Schicht-Darstellung innerhalb eines Tages.

--- a/CoShift/src/main/java/org/coshift/c_adapters/presentation/Presenter.java
+++ b/CoShift/src/main/java/org/coshift/c_adapters/presentation/Presenter.java
@@ -38,7 +38,9 @@ public class Presenter implements PresenterInputPort {
     public void showShifts(LocalDate monday, int weeks, List<Shift> shifts) {
         int totalDays = weeks * 7;
         List<DayCellViewModel> cells = new ArrayList<>(totalDays);
-        for (int i=0;i<totalDays;i++) cells.add(new DayCellViewModel(new ArrayList<>()));
+        for (int i = 0; i < totalDays; i++) {
+            cells.add(new DayCellViewModel(monday.plusDays(i), new ArrayList<>()));
+        }
 
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("HH:mm");
 
@@ -63,8 +65,12 @@ public class Presenter implements PresenterInputPort {
 
     private List<DayCellViewModel> createDayCells(List<ShiftSummeryDto> dtos) {
         // leere Woche vorbereiten
+        LocalDate today = LocalDate.now();
+        LocalDate monday = today.minusDays((today.getDayOfWeek().getValue() + 6) % 7);
         List<DayCellViewModel> cells = new ArrayList<>(7);
-        for (int i=0;i<7;i++) cells.add(new DayCellViewModel(new ArrayList<>()));
+        for (int i = 0; i < 7; i++) {
+            cells.add(new DayCellViewModel(monday.plusDays(i), new ArrayList<>()));
+        }
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
         //DateTimeFormatter ISO = DateTimeFormatter.ISO_LOCAL_DATE_TIME; // ISO 8601 format

--- a/CoShift/src/test/java/org/coshift/c_adapters/WeekViewModelTest.java
+++ b/CoShift/src/test/java/org/coshift/c_adapters/WeekViewModelTest.java
@@ -3,6 +3,8 @@ package org.coshift.c_adapters;
 import org.coshift.c_adapters.presentation.DayCellViewModel;
 import org.coshift.c_adapters.presentation.WeekViewModel;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,7 +14,7 @@ class WeekViewModelTest {
     @Test
     void renderStoresCellsForLaterRetrieval() {
         WeekViewModel model = new WeekViewModel();
-        List<DayCellViewModel> cells = List.of(new DayCellViewModel(List.of()));
+        List<DayCellViewModel> cells = List.of(new DayCellViewModel(LocalDate.now(), List.of()));
 
         model.render(cells);
 


### PR DESCRIPTION
## Summary
- include the date in week view cells so days can be identified
- add a DayPage that shows a day's shifts and assigned members on a time grid
- enable navigation from the week view to the new day view

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689080a991b0832dae2cf0ecf6e73b92