### PR TITLE
refactor: extract ShiftBlock component

### DIFF
--- a/CoShift/frontend/src/components/ShiftBlock.tsx
+++ b/CoShift/frontend/src/components/ShiftBlock.tsx
@@ -1,0 +1,26 @@
+import { Box, type BoxProps } from '@mui/material'
+
+interface ShiftBlockProps extends BoxProps {
+  filled: boolean
+  text: string
+}
+
+export default function ShiftBlock({ filled, text, sx, ...rest }: ShiftBlockProps) {
+  return (
+    <Box
+      {...rest}
+      sx={{
+        bgcolor: filled ? 'success.main' : 'grey.600',
+        color: filled ? 'common.white' : 'text.primary',
+        fontWeight: filled ? 600 : 'normal',
+        borderRadius: 1,
+        m: 0.5,
+        p: 0.5,
+        fontSize: '0.85rem',
+        ...(sx ?? {}),
+      }}
+    >
+      {text}
+    </Box>
+  )
+}

--- a/CoShift/frontend/src/pages/dayPage/DayPage.tsx
+++ b/CoShift/frontend/src/pages/dayPage/DayPage.tsx
@@ -2,20 +2,8 @@ import { Box } from '@mui/material'
 import { useParams } from 'react-router-dom'
 import { useApi } from '../api.ts'
 import { useQuery } from '@tanstack/react-query'
-
-interface ShiftPerson {
-  id: number
-  nickname: string
-  role: string
-}
-
-interface ShiftDetail {
-  id: number
-  startTime: string
-  durationInMinutes: number
-  capacity: number
-  persons: ShiftPerson[]
-}
+import ShiftBlock from '../../components/ShiftBlock.tsx'
+import type { ShiftDetail } from '../../types/shift.ts'
 
 export default function DayPage() {
   const { date = '' } = useParams<{ date: string }>()
@@ -74,23 +62,19 @@ export default function DayPage() {
           const height = shift.durationInMinutes * pxPerMinute
           const names = shift.persons.map(p => p.nickname).join(', ')
           return (
-            <Box
+            <ShiftBlock
               key={shift.id}
+              filled={shift.persons.length > 0}
+              text={names || 'frei'}
               sx={{
                 position: 'absolute',
                 top,
                 height,
                 left: 0,
                 right: 0,
-                bgcolor: 'secondary.main',
-                color: 'secondary.contrastText',
-                borderRadius: 1,
-                p: 0.5,
                 overflow: 'hidden',
               }}
-            >
-              {names || 'frei'}
-            </Box>
+            />
           )
         })}
       </Box>

--- a/CoShift/frontend/src/pages/weekPage/components/DayCell.tsx
+++ b/CoShift/frontend/src/pages/weekPage/components/DayCell.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 import type { DayCellViewModel } from '../types/dayCellView.ts'
+import ShiftBlock from '../../../components/ShiftBlock.tsx'
 
 export default function DayCell({ cell }: { cell: DayCellViewModel }) {
   const navigate = useNavigate()
@@ -15,20 +16,7 @@ export default function DayCell({ cell }: { cell: DayCellViewModel }) {
       )}
 
       {cell.shifts.map((s, i) => (
-        <Box
-          key={i}
-          sx={{
-            bgcolor: s.fullyStaffed ? 'success.main' : 'grey.600',
-            color: s.fullyStaffed ? 'common.white' : 'text.primary',
-            fontWeight: s.fullyStaffed ? 600 : 'normal',
-            borderRadius: 1,
-            m: 0.5,
-            p: 0.5,
-            fontSize: '0.85rem',
-          }}
-        >
-          {s.startTime}
-        </Box>
+        <ShiftBlock key={i} filled={s.fullyStaffed} text={s.startTime} />
       ))}
     </Box>
   )

--- a/CoShift/frontend/src/types/shift.ts
+++ b/CoShift/frontend/src/types/shift.ts
@@ -1,0 +1,13 @@
+export interface ShiftPerson {
+  id: number
+  nickname: string
+  role: string
+}
+
+export interface ShiftDetail {
+  id: number
+  startTime: string
+  durationInMinutes: number
+  capacity: number
+  persons: ShiftPerson[]
+}


### PR DESCRIPTION
## Summary
- add reusable `ShiftBlock` for displaying shift info
- reuse `ShiftBlock` in week and day pages
- centralize `ShiftPerson` and `ShiftDetail` interfaces in `types/shift.ts`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890887cdeec832d94b5ac4a02b6c99e