### PR TITLE
fix: remove person from shift

### DIFF
--- a/CoShift/src/main/java/org/coshift/a_domain/person/Person.java
+++ b/CoShift/src/main/java/org/coshift/a_domain/person/Person.java
@@ -65,4 +65,17 @@ public class Person {
         this.role = role;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Person person = (Person) o;
+        return id == person.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
 }

--- a/CoShift/src/test/java/org/coshift/b_application/ConfigurePersonsInShiftUseCaseTest.java
+++ b/CoShift/src/test/java/org/coshift/b_application/ConfigurePersonsInShiftUseCaseTest.java
@@ -73,4 +73,34 @@ class ConfigurePersonsInShiftUseCaseTest {
     }
 
 
+    @Test
+    void removePerson_persists_updated_shift() {
+        // Arrange ----------------------------------------------------------
+        ShiftRepository shiftRepo = mock(ShiftRepository.class);
+        PersonRepository personRepo = mock(PersonRepository.class);
+        ConfigurePersonsInShiftUseCase useCase = new ConfigurePersonsInShiftUseCase(shiftRepo, personRepo);
+
+        long shiftId = 3L;
+        long personId = 8L;
+        Person person = new Person(personId, "Eve", "pwd");
+        Shift shift = new Shift(shiftId, LocalDateTime.of(2025, 6, 24, 10, 0), 90, 2);
+        shift.addPerson(person);
+
+        when(shiftRepo.findById(shiftId)).thenReturn(Optional.of(shift));
+        when(personRepo.findById(personId)).thenReturn(Optional.of(person));
+        when(shiftRepo.save(any(Shift.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // Act --------------------------------------------------------------
+        Shift result = useCase.remove(personId, shiftId);
+
+        // Assert -----------------------------------------------------------
+        verify(shiftRepo).findById(shiftId);
+        verify(personRepo).findById(personId);
+        verify(shiftRepo).save(shift);
+
+        assertFalse(shift.getPersons().contains(person));
+        assertSame(shift, result);
+    }
+
+
 }


### PR DESCRIPTION
## Summary
- ensure Person entities compare by id so removal works
- add regression test for removing a person from a shift

## Testing
- `npm test --prefix frontend` *(fails: Missing script "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6890b485c6c8832d872318c6cb6823c6