### PR TITLE
fix: support unicode credentials in login

### DIFF
--- a/CoShift/frontend/src/features/auth/components/LoginForm.tsx
+++ b/CoShift/frontend/src/features/auth/components/LoginForm.tsx
@@ -14,7 +14,7 @@ export default function Login({ onLogin }: Props) {
   async function submit(e: FormEvent) {
     e.preventDefault()
     setError(null)                               // alte Fehlermeldung zurücksetzen
-    const token   = btoa(`${user}:${pass}`)
+    const token   = btoa(unescape(encodeURIComponent(`${user}:${pass}`)))
     const success = await onLogin(`Basic ${token}`)
 
     if (!success) {


### PR DESCRIPTION
## Summary
- encode login credentials in Base64 with UTF-8 to support special characters

## Testing
- `npm run lint`
- `node - <<'NODE'
const user = 'Äö';
const pass = 'Üß';
const token = btoa(unescape(encodeURIComponent(`${user}:${pass}`)));
console.log('token:', token);
const decoded = decodeURIComponent(escape(atob(token)));
console.log('decoded:', decoded);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6890b99e8424832d8ad95bad72ddc0ed