### PR TITLE
feat: add time picker for shift dialogs

### DIFF
--- a/CoShift/frontend/package-lock.json
+++ b/CoShift/frontend/package-lock.json
@@ -12,8 +12,10 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
+        "@mui/x-date-pickers": "^7.29.4",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-query-devtools": "^5.83.0",
+        "dayjs": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1"
@@ -1405,6 +1407,92 @@
         }
       }
     },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.29.4.tgz",
+      "integrity": "sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+        "@mui/x-internals": "7.29.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
+      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2468,6 +2556,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/CoShift/frontend/package.json
+++ b/CoShift/frontend/package.json
@@ -14,8 +14,10 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
+    "@mui/x-date-pickers": "^7.29.4",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-query-devtools": "^5.83.0",
+    "dayjs": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1"

--- a/CoShift/frontend/src/pages/configureShifts/components/AddShiftDialog.tsx
+++ b/CoShift/frontend/src/pages/configureShifts/components/AddShiftDialog.tsx
@@ -1,5 +1,18 @@
 import { useState } from 'react'
-import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button } from '@mui/material'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from '@mui/material'
+import {
+  LocalizationProvider,
+  DateTimePicker,
+} from '@mui/x-date-pickers'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
+import { Dayjs } from 'dayjs'
 import type { NewShiftDto } from '../types/shift.ts'
 
 interface Props {
@@ -9,51 +22,57 @@ interface Props {
 }
 
 export default function AddShiftDialog({ open, onClose, onSave }: Props) {
-  const [start, setStart] = useState('')
+  const [start, setStart] = useState<Dayjs | null>(null)
   const [duration, setDuration] = useState(60)
   const [capacity, setCapacity] = useState(1)
 
-  const canSave = start.trim() !== '' && duration > 0 && capacity > 0
+  const canSave = start !== null && duration > 0 && capacity > 0
 
   const handleSave = () => {
-    if (!canSave) return
-    onSave({ startTime: start, durationInMinutes: duration, capacity })
-    setStart('')
+    if (!canSave || !start) return
+    onSave({
+      startTime: start.format('YYYY-MM-DDTHH:mm'),
+      durationInMinutes: duration,
+      capacity,
+    })
+    setStart(null)
     setDuration(60)
     setCapacity(1)
     onClose()
   }
 
   return (
-    <Dialog open={open} onClose={onClose}>
-      <DialogTitle>Neue Schicht anlegen</DialogTitle>
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-        <TextField
-          label="Start"
-          type="datetime-local"
-          value={start}
-          onChange={e => setStart(e.target.value)}
-          InputLabelProps={{ shrink: true }}
-        />
-        <TextField
-          label="Dauer (Minuten)"
-          type="number"
-          value={duration}
-          onChange={e => setDuration(Number(e.target.value))}
-        />
-        <TextField
-          label="Kapazität"
-          type="number"
-          value={capacity}
-          onChange={e => setCapacity(Number(e.target.value))}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Abbrechen</Button>
-        <Button variant="contained" onClick={handleSave} disabled={!canSave}>
-          Speichern
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Dialog open={open} onClose={onClose}>
+        <DialogTitle>Neue Schicht anlegen</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <DateTimePicker
+            label="Start"
+            value={start}
+            onChange={value => setStart(value)}
+            ampm={false}
+            slotProps={{ textField: { InputLabelProps: { shrink: true } } }}
+          />
+          <TextField
+            label="Dauer (Minuten)"
+            type="number"
+            value={duration}
+            onChange={e => setDuration(Number(e.target.value))}
+          />
+          <TextField
+            label="Kapazität"
+            type="number"
+            value={capacity}
+            onChange={e => setCapacity(Number(e.target.value))}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Abbrechen</Button>
+          <Button variant="contained" onClick={handleSave} disabled={!canSave}>
+            Speichern
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </LocalizationProvider>
   )
 }

--- a/CoShift/frontend/src/pages/configureShifts/components/EditShiftDialog.tsx
+++ b/CoShift/frontend/src/pages/configureShifts/components/EditShiftDialog.tsx
@@ -1,5 +1,18 @@
 import { useState, useEffect } from 'react'
-import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button } from '@mui/material'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+} from '@mui/material'
+import {
+  LocalizationProvider,
+  DateTimePicker,
+} from '@mui/x-date-pickers'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import type { ShiftDto } from '../types/shift.ts'
 
 interface Props {
@@ -9,56 +22,63 @@ interface Props {
 }
 
 export default function EditShiftDialog({ shift, onClose, onSave }: Props) {
-  const [start, setStart] = useState('')
+  const [start, setStart] = useState<Dayjs | null>(null)
   const [duration, setDuration] = useState(60)
   const [capacity, setCapacity] = useState(1)
 
   useEffect(() => {
     if (shift) {
-      setStart(shift.startTime)
+      setStart(dayjs(shift.startTime))
       setDuration(shift.durationInMinutes)
       setCapacity(shift.capacity)
     }
   }, [shift])
 
-  const canSave = start.trim() !== '' && duration > 0 && capacity > 0 && shift !== null
+  const canSave = start !== null && duration > 0 && capacity > 0 && shift !== null
 
   const handleSave = () => {
-    if (!shift || !canSave) return
-    onSave({ ...shift, startTime: start, durationInMinutes: duration, capacity })
+    if (!shift || !canSave || !start) return
+    onSave({
+      ...shift,
+      startTime: start.format('YYYY-MM-DDTHH:mm'),
+      durationInMinutes: duration,
+      capacity,
+    })
     onClose()
   }
 
   return (
-    <Dialog open={!!shift} onClose={onClose}>
-      <DialogTitle>Schicht bearbeiten</DialogTitle>
-      <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-        <TextField
-          label="Start"
-          type="datetime-local"
-          value={start}
-          onChange={e => setStart(e.target.value)}
-          InputLabelProps={{ shrink: true }}
-        />
-        <TextField
-          label="Dauer (Minuten)"
-          type="number"
-          value={duration}
-          onChange={e => setDuration(Number(e.target.value))}
-        />
-        <TextField
-          label="Kapazität"
-          type="number"
-          value={capacity}
-          onChange={e => setCapacity(Number(e.target.value))}
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Abbrechen</Button>
-        <Button variant="contained" onClick={handleSave} disabled={!canSave}>
-          Speichern
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Dialog open={!!shift} onClose={onClose}>
+        <DialogTitle>Schicht bearbeiten</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <DateTimePicker
+            label="Start"
+            value={start}
+            onChange={value => setStart(value)}
+            ampm={false}
+            slotProps={{ textField: { InputLabelProps: { shrink: true } } }}
+          />
+          <TextField
+            label="Dauer (Minuten)"
+            type="number"
+            value={duration}
+            onChange={e => setDuration(Number(e.target.value))}
+          />
+          <TextField
+            label="Kapazität"
+            type="number"
+            value={capacity}
+            onChange={e => setCapacity(Number(e.target.value))}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Abbrechen</Button>
+          <Button variant="contained" onClick={handleSave} disabled={!canSave}>
+            Speichern
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </LocalizationProvider>
   )
 }


### PR DESCRIPTION
## Summary
- allow selecting shift start date and time via MUI DateTimePicker in add/edit dialogs
- add @mui/x-date-pickers and dayjs dependencies

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`
- `mvn -q test` (fails: could not resolve spring-boot-starter-parent)


------
https://chatgpt.com/codex/tasks/task_e_6891bd10e4c4832dbaef4f1849ed5e6b