### PR TITLE
feat(frontend): show calendar week numbers

### DIFF
--- a/CoShift/frontend/src/pages/weekPage/WeekPage.tsx
+++ b/CoShift/frontend/src/pages/weekPage/WeekPage.tsx
@@ -3,6 +3,11 @@ import { Box } from '@mui/material'
 import { useApi } from '../api.ts'
 import { useQuery } from '@tanstack/react-query'
 import type { DayCellViewModel } from './types/dayCellView.ts'
+import dayjs from 'dayjs'
+import isoWeek from 'dayjs/plugin/isoWeek'
+import { Fragment } from 'react'
+
+dayjs.extend(isoWeek)
 
 export default function WeekPage() {
   const api = useApi()
@@ -16,6 +21,14 @@ export default function WeekPage() {
 
   // Kopfzeile
   const days = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So']
+  const headerSx = {
+    fontWeight: 'bold',
+    p: 0.5,
+    bgcolor: 'background.paper',
+    border: 1,
+    borderColor: 'divider',
+    textAlign: 'center',
+  } as const
 
   // Fallback: solange noch keine Daten da sind, leere Zellen anzeigen
   const empty: DayCellViewModel = { date: '', shifts: [] }
@@ -23,31 +36,33 @@ export default function WeekPage() {
     ? cells
     : Array.from({ length: EXPECTED }, () => empty)
 
+  const weeks = Array.from({ length: weeksToShow }, (_, i) =>
+    display.slice(i * 7, (i + 1) * 7),
+  )
+
   return (
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(7, 1fr)',
+        gridTemplateColumns: '4rem repeat(7, 1fr)',
         gap: 2,                       // theme.spacing(2) → 2*4px
       }}
     >
+      <Box sx={headerSx}>KW</Box>
       {days.map(day => (
-        <Box
-          key={day}
-          sx={{
-            fontWeight: 'bold',
-            p: 0.5,
-            bgcolor: 'background.paper',
-            border: 1,
-            borderColor: 'divider',
-            textAlign: 'center',
-          }}
-        >
+        <Box key={day} sx={headerSx}>
           {day}
         </Box>
       ))}
-      {display.map((cell, idx) => (
-        <DayCell key={idx} cell={cell} />
+      {weeks.map((week, wIdx) => (
+        <Fragment key={wIdx}>
+          <Box sx={headerSx}>
+            {week[0].date ? `KW ${dayjs(week[0].date).isoWeek()}` : ''}
+          </Box>
+          {week.map((cell, idx) => (
+            <DayCell key={wIdx * 7 + idx} cell={cell} />
+          ))}
+        </Fragment>
       ))}
     </Box>
   )


### PR DESCRIPTION
## Summary
- show calendar week numbers on week overview page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `./mvnw -q test` (fails: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_6891c6665100832dbe14b95fca84f945