### PR TITLE
feat(frontend): show date in week cells

### DIFF
--- a/CoShift/frontend/src/pages/weekPage/components/DayCell.tsx
+++ b/CoShift/frontend/src/pages/weekPage/components/DayCell.tsx
@@ -2,18 +2,30 @@ import { Box } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 import type { DayCellViewModel } from '../types/dayCellView.ts'
 import ShiftBlock from '../../ShiftBlock.tsx'
+import dayjs from 'dayjs'
 
 export default function DayCell({ cell }: { cell: DayCellViewModel }) {
   const navigate = useNavigate()
 
   return (
     <Box
-      sx={{ minHeight: '4rem', border: 1, borderColor: 'divider', cursor: 'pointer' }}
+      sx={{
+        minHeight: '4rem',
+        border: 1,
+        borderColor: 'divider',
+        cursor: 'pointer',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
       onClick={() => cell.date && navigate(`/day/${cell.date}`)}
     >
-      {cell.shifts.length === 0 && (
-        <Box sx={{ opacity: 0.3 }}>&nbsp;</Box>
+      {cell.date && (
+        <Box sx={{ fontSize: '0.75rem', textAlign: 'right', px: 0.5, pt: 0.5 }}>
+          {dayjs(cell.date).format('DD.MM.YY')}
+        </Box>
       )}
+
+      {cell.shifts.length === 0 && <Box sx={{ opacity: 0.3 }}>&nbsp;</Box>}
 
       {cell.shifts.map((s, i) => (
         <ShiftBlock key={i} filled={s.fullyStaffed} text={s.startTime} />


### PR DESCRIPTION
## Summary
- display the corresponding date at the top of each week cell
- use dayjs to format dates as `dd.mm.yy` and adjust layout

## Testing
- `npm run lint`
- `./mvnw -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891cda18e88832db53b68af01a85236