### PR TITLE
Use BCrypt to secure stored passwords

### DIFF
--- a/CoShift/data/persons/persons.json
+++ b/CoShift/data/persons/persons.json
@@ -2,28 +2,28 @@
   {
     "id": 1,
     "nickname": "anton",
-    "password": "secret",
+    "password": "$2b$12$KVcFEupQDxK0zzrBIUnWVuX2IOq3aI8mJVUmlgl50qk5DNWvJo9uu",
     "timeAccountId": 1,
     "role": "ADMIN"
   },
   {
     "id": 2,
     "nickname": "berta",
-    "password": "secret",
+    "password": "$2b$12$J6CJaYbG8IfjH.goJUaOvO3d8Nt9doaUUjMiV3fPApWDy/1ZQKt66",
     "timeAccountId": 2,
     "role": "USER"
   },
   {
     "id": 3,
     "nickname": "cäsar",
-    "password": "secret",
+    "password": "$2b$12$/IpDuVJ7GFfzkoacpqvLx.yt/yb77Exwd/1NGqzSRKlSvovqfYetm",
     "timeAccountId": 3,
     "role": "ADMIN"
   },
   {
     "id": 4,
     "nickname": "philipp",
-    "password": "secret",
+    "password": "$2b$12$/LmXw2zkLqZ2bKplgADlAuesWHqVlkYp6K9nAeNFcEUwfXTQCNtIO",
     "timeAccountId": 4,
     "role": "ADMIN"
   }

--- a/CoShift/src/main/java/org/coshift/b_application/UseCaseInteractor.java
+++ b/CoShift/src/main/java/org/coshift/b_application/UseCaseInteractor.java
@@ -40,7 +40,7 @@ public class UseCaseInteractor {
             PresenterInputPort presenter
     ) {
         this.configureShiftUC  = new ConfigureShiftUseCase(shiftRepository);
-        this.configurePersonUC = new ConfigurePersonUseCase(personRepository, timeAccountRepository);
+        this.configurePersonUC = new ConfigurePersonUseCase(personRepository, timeAccountRepository, passwordChecker);
         this.configurePersonsInShiftUseCase = new ConfigurePersonsInShiftUseCase(shiftRepository, personRepository);
         this.authenticateUserUC = new AuthenticateUserUseCase(personRepository, passwordChecker);
         this.viewTimeAccountUC = new ViewTimeAccountUseCase(timeAccountRepository, personRepository);

--- a/CoShift/src/main/java/org/coshift/d_frameworks/config/SpringConfig.java
+++ b/CoShift/src/main/java/org/coshift/d_frameworks/config/SpringConfig.java
@@ -9,7 +9,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.coshift.b_application.useCases.AuthenticateUserUseCase;
 import org.coshift.b_application.ports.PersonRepository;
 import org.coshift.b_application.ports.PasswordChecker;
@@ -55,16 +54,10 @@ public class SpringConfig {
         return http.build();
     }
 
-    @Bean  // ToDo: löschen und unten einkommentieren
+    @Bean
     PasswordEncoder passwordEncoder() {
-        return NoOpPasswordEncoder.getInstance();  
+        return new BCryptPasswordEncoder();
     }
-
-    // ToDo: einkommentieren und oben löschen
-    // @Bean
-    // PasswordEncoder passwordEncoder() {
-    //     return new BCryptPasswordEncoder();
-    // }
 
     @Bean
     AuthenticateUserUseCase authUC(PersonRepository repo, PasswordChecker checker){


### PR DESCRIPTION
## Summary
- Replace insecure NoOp password encoder with BCrypt-based encoder
- Hash passwords on create/update via PasswordChecker
- Convert existing user records to store BCrypt hashes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_6891e210aa5c832d8c317c1161281105