### PR TITLE
Enable CSRF protection and send token from frontend

### DIFF
--- a/CoShift/src/main/java/org/coshift/d_frameworks/config/SpringConfig.java
+++ b/CoShift/src/main/java/org/coshift/d_frameworks/config/SpringConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.coshift.b_application.useCases.AuthenticateUserUseCase;
 import org.coshift.b_application.ports.PersonRepository;
 import org.coshift.b_application.ports.PasswordChecker;
@@ -44,7 +45,7 @@ public class SpringConfig {
         AuthenticationProvider ucProvider
     ) throws Exception {
         http
-          .csrf(c -> c.disable())
+          .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
           .authenticationProvider(ucProvider)
           .authorizeHttpRequests(a -> a
                   .requestMatchers("/api/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
## Summary
- enable CookieCsrfTokenRepository so Spring Security issues CSRF tokens
- send X-XSRF-TOKEN header from frontend for POST/PUT/DELETE requests

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact: Network is unreachable)*
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891e266ea58832da6a42e75cd9ba461