### PR TITLE
Restrict person role management to admins

### DIFF
--- a/CoShift/src/main/java/org/coshift/c_adapters/web/PersonController.java
+++ b/CoShift/src/main/java/org/coshift/c_adapters/web/PersonController.java
@@ -16,7 +16,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * REST-Controller für Personen-bezogene Funktionen
@@ -42,17 +41,13 @@ public class PersonController {
 
     /* ---------- CREATE ---------------------------------------------- */
 
-    // Einfaches DTO fürs Anlegen neuer Personen (Role optional)
-    public record NewPersonDto(String nickname, String password, String role) {}
+    // Einfaches DTO fürs Anlegen neuer Personen
+    public record NewPersonDto(String nickname, String password) {}
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public PersonPublicDto create(@RequestBody NewPersonDto dto) {
-        PersonRole role = Optional.ofNullable(dto.role())
-                .map(String::toUpperCase)
-                .map(PersonRole::valueOf)
-                .orElse(PersonRole.USER);
-
-        Person p = interactor.addPerson(dto.nickname(), dto.password(), role);
+        Person p = interactor.addPerson(dto.nickname(), dto.password());
         return PersonMapper.toPublicDto(p);
     }
 
@@ -101,6 +96,7 @@ public class PersonController {
     /* ---------- UPDATE ---------------------------------------------- */
 
     @PutMapping("/{id}/role")
+    @PreAuthorize("hasRole('ADMIN')")
     public PersonPublicDto updateRole(@PathVariable long id, @RequestBody PersonRole role) {
         Person person = interactor.updatePersonRole(id, role);
         return PersonMapper.toPublicDto(person);
@@ -110,9 +106,7 @@ public class PersonController {
     @PreAuthorize("hasRole('ADMIN')")
     public PersonPublicDto update(@PathVariable long id,
                                   @RequestBody NewPersonDto dto){
-        PersonRole role = dto.role()==null? null
-                : PersonRole.valueOf(dto.role().toUpperCase());
-        Person p = interactor.updatePerson(id, dto.nickname(), dto.password(), role);
+        Person p = interactor.updatePerson(id, dto.nickname(), dto.password(), null);
         return PersonMapper.toPublicDto(p);
     }
 

--- a/CoShift/src/main/java/org/coshift/d_frameworks/config/SpringConfig.java
+++ b/CoShift/src/main/java/org/coshift/d_frameworks/config/SpringConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -22,6 +23,7 @@ import org.coshift.c_adapters.ports.TimeAccountJsonFileAccessor;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SpringConfig {
 
     @Bean

--- a/CoShift/src/test/java/org/coshift/PersonControllerSecurityTest.java
+++ b/CoShift/src/test/java/org/coshift/PersonControllerSecurityTest.java
@@ -1,0 +1,95 @@
+package org.coshift;
+
+import org.coshift.a_domain.person.Person;
+import org.coshift.a_domain.person.PersonRole;
+import org.coshift.b_application.UseCaseInteractor;
+import org.coshift.b_application.ports.PersonRepository;
+import org.coshift.b_application.ports.TimeAccountRepository;
+import org.coshift.c_adapters.web.PersonController;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+
+@WebMvcTest(PersonController.class)
+@Import(PersonControllerSecurityTest.TestConfig.class)
+class PersonControllerSecurityTest {
+
+    @Configuration
+    @EnableMethodSecurity
+    static class TestConfig {
+    }
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    UseCaseInteractor interactor;
+
+    @MockBean
+    PersonRepository persons;
+
+    @MockBean
+    TimeAccountRepository accounts;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminCanCreatePerson() throws Exception {
+        when(interactor.addPerson(anyString(), anyString()))
+                .thenReturn(new Person(1L, "nick", "pw"));
+
+        mvc.perform(post("/api/persons")
+                .with(csrf())
+                .contentType("application/json")
+                .content("{\"nickname\":\"nick\",\"password\":\"pw\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    void userCannotCreatePerson() throws Exception {
+        mvc.perform(post("/api/persons")
+                .with(csrf())
+                .contentType("application/json")
+                .content("{\"nickname\":\"nick\",\"password\":\"pw\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminCanChangeRole() throws Exception {
+        when(interactor.updatePersonRole(anyLong(), ArgumentMatchers.any(PersonRole.class)))
+                .thenReturn(new Person(1L, "nick", "pw", PersonRole.ADMIN));
+
+        mvc.perform(put("/api/persons/1/role")
+                .with(csrf())
+                .contentType("application/json")
+                .content("\"ADMIN\""))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    void userCannotChangeRole() throws Exception {
+        mvc.perform(put("/api/persons/1/role")
+                .with(csrf())
+                .contentType("application/json")
+                .content("\"ADMIN\""))
+                .andExpect(status().isForbidden());
+    }
+}
+


### PR DESCRIPTION
## Summary
- require ADMIN role to create or change person roles
- ensure new person DTO cannot set roles directly
- enable method-level security and add controller tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891f8910cbc832dbf9bb67ce53ee229